### PR TITLE
Stop linter from crashing

### DIFF
--- a/lib/factory_girl/linter.rb
+++ b/lib/factory_girl/linter.rb
@@ -22,9 +22,13 @@ module FactoryGirl
     def calculate_invalid_factories
       factories_to_lint.select do |factory|
         built_factory = FactoryGirl.build(factory.name)
-
-        if built_factory.respond_to?(:valid?)
-          !built_factory.valid?
+        begin
+          built_factory = FactoryGirl.build(factory.name)
+          if built_factory.respond_to?(:valid?)
+            !built_factory.valid?
+          end
+        rescue
+          true
         end
       end
     end


### PR DESCRIPTION
I was getting the following error messages from running lint which wasn't very helpful.

```
/Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activerecord-3.2.18/lib/active_record/validations.rb:56:in `save!': Validation failed: Gym can't be blank (ActiveRecord::RecordInvalid)
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activerecord-3.2.18/lib/active_record/attribute_methods/dirty.rb:33:in `save!'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activerecord-3.2.18/lib/active_record/transactions.rb:264:in `block in save!'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activerecord-3.2.18/lib/active_record/transactions.rb:313:in `block in with_transaction_returning_status'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activerecord-3.2.18/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activerecord-3.2.18/lib/active_record/transactions.rb:208:in `transaction'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activerecord-3.2.18/lib/active_record/transactions.rb:311:in `with_transaction_returning_status'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activerecord-3.2.18/lib/active_record/transactions.rb:264:in `save!'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/configuration.rb:14:in `block in initialize'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/evaluation.rb:15:in `[]'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/evaluation.rb:15:in `create'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/strategy/create.rb:12:in `block in result'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/strategy/create.rb:9:in `tap'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/strategy/create.rb:9:in `result'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/factory.rb:42:in `run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/factory_runner.rb:23:in `block in run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activesupport-3.2.18/lib/active_support/notifications.rb:125:in `instrument'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/factory_runner.rb:22:in `run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/strategy/build.rb:5:in `association'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/evaluator.rb:31:in `association'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/attribute/association.rb:19:in `block in to_proc'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/evaluator.rb:71:in `instance_exec'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/evaluator.rb:71:in `block in define_attribute'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/attribute_assigner.rb:56:in `get'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/attribute_assigner.rb:16:in `block (2 levels) in object'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/attribute_assigner.rb:15:in `each'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/attribute_assigner.rb:15:in `block in object'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/attribute_assigner.rb:14:in `tap'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/attribute_assigner.rb:14:in `object'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/evaluation.rb:12:in `object'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/strategy/build.rb:9:in `result'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/factory.rb:42:in `run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/factory_runner.rb:23:in `block in run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/activesupport-3.2.18/lib/active_support/notifications.rb:125:in `instrument'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/factory_runner.rb:22:in `run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/strategy_syntax_method_registrar.rb:20:in `block in define_singular_strategy_method'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/linter.rb:25:in `block in calculate_invalid_factories'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/registry.rb:17:in `each'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/registry.rb:17:in `each'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/decorator.rb:10:in `select'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/decorator.rb:10:in `method_missing'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/linter.rb:24:in `calculate_invalid_factories'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/linter.rb:9:in `initialize'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/linter.rb:4:in `new'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl/linter.rb:4:in `lint!'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/bundler/gems/factory_girl-7e2bed5938be/lib/factory_girl.rb:59:in `lint'
   from /Users/mhenrixon/code/kiskolabs/WODconnect/spec/support/factory_girl.rb:5:in `block (2 levels) in <top (required)'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:23:in `instance_eval'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:23:in `run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:63:in `block in run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:63:in `each'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:63:in `run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:400:in `run_hook'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:27:in `block in run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/reporter.rb:34:in `report'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:25:in `run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/runner.rb:69:in `run'
   from /Users/mhenrixon/.rvm/gems/ruby-2.1.2/gems/rspec-core-2.10.1/lib/rspec/core/runner.rb:10:in `block in autorun'
```

This is what I did to fix that so that I am at least presented with a list of factories to fix.