### PR TITLE
Detailed list syntax method

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -866,6 +866,23 @@ built_users   = build_pair(:user) # array of two built users
 created_users = create_pair(:user) # array of two created users
 ```
 
+If you need to specify certain attributes for *some* of the records, you can supply an array
+in the hash of attributes instead of a single value - though be sure to pluralize the name!
+
+```ruby
+built_users   = build_detailed_list(:user, 25, names: ['Arthur', 'Ford', 'Marvin'] 
+created_users = create_detailed_list(:user, 25, names: ['Arthur', 'Ford', 'Marvin'] 
+# User.first.name => "Arthur", User.second.name => "Ford"
+```
+
+This approach also works with traits and attributes you wish to override for *every* record.
+
+```ruby
+created_users = create_detailed_list(:user, 25, names: ['Arthur', 'Ford'], name: 'Marvin') 
+# User.first.name => Arthur, User.second.name = "Ford", User.last.name = "Marvin"
+```
+
+
 Custom Construction
 -------------------
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -860,7 +860,8 @@ twenty_year_olds = build_list(:user, 25, date_of_birth: 20.years.ago)
 ```
 
 If you need to specify certain attributes for *some* of the records, you can supply an array
-in the hash of attributes instead of a single value - though be sure to pluralize the name!
+in the hash of attributes instead of a single value - be sure to pluralize the name when providing
+an array!
 
 ```ruby
 built_users   = build_detailed_list(:user, 25, names: ['Arthur', 'Ford', 'Marvin']) 
@@ -872,7 +873,7 @@ This approach also works with traits and attributes you wish to override for *ev
 
 ```ruby
 created_users = create_detailed_list(:user, 25, names: ['Arthur', 'Ford'], name: 'Marvin')
-# User.first.name => Arthur, User.second.name = "Ford", User.last.name = "Marvin"
+# User.first.name => Arthur, User.second.name => "Ford", User.last.name => "Marvin"
 ```
 
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -859,29 +859,29 @@ To set the attributes for each of the factories, you can pass in a hash as you n
 twenty_year_olds = build_list(:user, 25, date_of_birth: 20.years.ago)
 ```
 
-There's also a set of `*_pair` methods for creating two records at a time:
-
-```ruby
-built_users   = build_pair(:user) # array of two built users
-created_users = create_pair(:user) # array of two created users
-```
-
 If you need to specify certain attributes for *some* of the records, you can supply an array
 in the hash of attributes instead of a single value - though be sure to pluralize the name!
 
 ```ruby
-built_users   = build_detailed_list(:user, 25, names: ['Arthur', 'Ford', 'Marvin'] 
-created_users = create_detailed_list(:user, 25, names: ['Arthur', 'Ford', 'Marvin'] 
+built_users   = build_detailed_list(:user, 25, names: ['Arthur', 'Ford', 'Marvin']) 
+created_users = create_detailed_list(:user, 25, names: ['Arthur', 'Ford', 'Marvin'])
 # User.first.name => "Arthur", User.second.name => "Ford"
 ```
 
 This approach also works with traits and attributes you wish to override for *every* record.
 
 ```ruby
-created_users = create_detailed_list(:user, 25, names: ['Arthur', 'Ford'], name: 'Marvin') 
+created_users = create_detailed_list(:user, 25, names: ['Arthur', 'Ford'], name: 'Marvin')
 # User.first.name => Arthur, User.second.name = "Ford", User.last.name = "Marvin"
 ```
 
+
+There's also a set of `*_pair` methods for creating two records at a time:
+
+```ruby
+built_users   = build_pair(:user) # array of two built users
+created_users = create_pair(:user) # array of two created users
+```
 
 Custom Construction
 -------------------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,20 +36,14 @@ GEM
     bourne (1.5.0)
       mocha (>= 0.13.2, < 0.15)
     builder (3.1.4)
-    byebug (3.4.0)
-      columnize (~> 0.8)
-      debugger-linecache (~> 1.2)
-      slop (~> 3.6)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
-    columnize (0.8.9)
     cucumber (1.3.15)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.1)
-    debugger-linecache (1.2.0)
     diff-lcs (1.1.3)
     ffi (1.9.0)
     ffi (1.9.0-java)
@@ -77,7 +71,6 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
-    slop (3.6.0)
     sqlite3 (1.3.8)
     thor (0.19.1)
     thread_safe (0.1.2)
@@ -97,7 +90,6 @@ DEPENDENCIES
   appraisal (~> 1.0.0)
   aruba
   bourne
-  byebug
   cucumber (~> 1.3.15)
   factory_girl!
   mocha (>= 0.12.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,14 +36,20 @@ GEM
     bourne (1.5.0)
       mocha (>= 0.13.2, < 0.15)
     builder (3.1.4)
+    byebug (3.4.0)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
+    columnize (0.8.9)
     cucumber (1.3.15)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.1)
+    debugger-linecache (1.2.0)
     diff-lcs (1.1.3)
     ffi (1.9.0)
     ffi (1.9.0-java)
@@ -71,6 +77,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
+    slop (3.6.0)
     sqlite3 (1.3.8)
     thor (0.19.1)
     thread_safe (0.1.2)
@@ -90,6 +97,7 @@ DEPENDENCIES
   appraisal (~> 1.0.0)
   aruba
   bourne
+  byebug
   cucumber (~> 1.3.15)
   factory_girl!
   mocha (>= 0.12.8)

--- a/factory_girl.gemspec
+++ b/factory_girl.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("bourne")
   s.add_development_dependency("appraisal", "~> 1.0.0")
   s.add_development_dependency("activerecord", ">= 3.0.0")
-
+  
   if RUBY_PLATFORM == "java"
     s.add_development_dependency("activerecord-jdbcsqlite3-adapter")
     s.add_development_dependency("jdbc-sqlite3")

--- a/lib/factory_girl/factory_runner.rb
+++ b/lib/factory_girl/factory_runner.rb
@@ -3,14 +3,12 @@ module FactoryGirl
     def initialize(name, strategy, traits_and_overrides)
       @name     = name
       @strategy = strategy
-
       @overrides = traits_and_overrides.extract_options!
       @traits    = traits_and_overrides
     end
 
     def run(runner_strategy = @strategy, &block)
       factory = FactoryGirl.factory_by_name(@name)
-
       factory.compile
 
       if @traits.any?

--- a/lib/factory_girl/strategy_syntax_method_registrar.rb
+++ b/lib/factory_girl/strategy_syntax_method_registrar.rb
@@ -8,6 +8,7 @@ module FactoryGirl
     def define_strategy_methods
       define_singular_strategy_method
       define_list_strategy_method
+      define_detailed_list_strategy_method
       define_pair_strategy_method
     end
 

--- a/lib/factory_girl/strategy_syntax_method_registrar.rb
+++ b/lib/factory_girl/strategy_syntax_method_registrar.rb
@@ -32,17 +32,18 @@ module FactoryGirl
 
     def define_detailed_list_strategy_method
       strategy_name = @strategy_name
-      define_syntax_method("#{strategy_name}_detailed_list") do |name, amount, *traits, **overrides, &block|
+      define_syntax_method("#{strategy_name}_detailed_list") do |name, amount, *traits_and_overrides, &block|
+        overrides = traits_and_overrides.extract_options!  
         amount.times.map.with_index { |i|
           values = {}
-          overrides.map { |key, value| 
+          overrides.map { |key, value|    
             if value.is_a? Array
               values[key.to_s.singularize] = value[i] unless value[i].nil? 
             else
               values[key] = value
             end
           }
-          send(strategy_name, name, traits.dup << values, &block) 
+          send(strategy_name, name, traits_and_overrides.dup << values, &block) 
         }
       end   
     end

--- a/lib/factory_girl/strategy_syntax_method_registrar.rb
+++ b/lib/factory_girl/strategy_syntax_method_registrar.rb
@@ -37,7 +37,7 @@ module FactoryGirl
           values = {}
           overrides.map { |key, value| 
             if value.is_a? Array
-              values[key] = value[i] unless value[i].nil? 
+              values[key.to_s.singularize] = value[i] unless value[i].nil? 
             else
               values[key] = value
             end

--- a/lib/factory_girl/strategy_syntax_method_registrar.rb
+++ b/lib/factory_girl/strategy_syntax_method_registrar.rb
@@ -29,6 +29,17 @@ module FactoryGirl
       end
     end
 
+    def define_detailed_list_strategy_method
+      strategy_name = @strategy_name
+      define_syntax_method("#{strategy_name}_detailed_list") do |name, amount, details, &block|
+        amount.times.map.with_index { |i|
+          overrides = {}
+          details.map{ |key, value| overrides[key] = value[i] unless value[i].nil?  } 
+          send(strategy_name, name, overrides, &block)
+        }
+      end   
+    end
+
     def define_pair_strategy_method
       strategy_name = @strategy_name
 

--- a/lib/factory_girl/strategy_syntax_method_registrar.rb
+++ b/lib/factory_girl/strategy_syntax_method_registrar.rb
@@ -34,16 +34,15 @@ module FactoryGirl
       strategy_name = @strategy_name
       define_syntax_method("#{strategy_name}_detailed_list") do |name, amount, *traits, **overrides, &block|
         amount.times.map.with_index { |i|
-          values, result = {}, traits.dup
+          values = {}
           overrides.map { |key, value| 
-            if value.is_a? Array 
+            if value.is_a? Array
               values[key] = value[i] unless value[i].nil? 
             else
               values[key] = value
             end
           }
-          result << values if values.length > 0
-          send(strategy_name, name, result, &block) 
+          send(strategy_name, name, traits.dup << values, &block) 
         }
       end   
     end

--- a/spec/acceptance/build_detailed_list_spec.rb
+++ b/spec/acceptance/build_detailed_list_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe "build multiple instances" do
+  before do
+    define_model('Post', title: :string, author: :string, position: :integer)
+  
+    FactoryGirl.define do
+      factory(:post) do |post|
+        post.title "Into the Blue Yonder"
+        post.author "High Lord Frank of the Summer Isles"
+        post.position { rand(10**4) }
+      end
+    end
+  end
+
+  context "with singular value for details" do
+    subject { FactoryGirl.build_detailed_list(:post, 20, 
+                                              title: ["Into the White Yonder"]) }
+    
+    its(:length) { should eq 20 }
+
+    it "builds (but doesn't save) all the posts" do
+      subject.each do |record|
+        expect(record).to be_new_record
+      end
+    end
+
+    it "overrides the value for the provided attribute for the first post" do
+      expect(subject.first.title).to eq "Into the White Yonder"
+    end
+
+    it "only overrides the first post in the list" do
+      subject[1..-1].each do |record|
+        expect(record.title).to eq "Into the Blue Yonder"
+      end
+    end
+
+    it "only overrides the provided attribute in the details hash" do
+      expect(subject.first.author).to eq "High Lord Frank of the Summer Isles"
+    end
+  end
+  
+  context "with a block" do
+    subject do 
+      FactoryGirl.build_detailed_list(:post, 20, title: [ "Into the White Yonder"]) do |post|
+        post.position = post.id
+      end
+    end
+
+    it "correctly uses the set value" do
+      subject.each_with_index do |record, index|
+        expect(record.position).to eq record.id 
+      end
+    end 
+  end
+end

--- a/spec/acceptance/create_detailed_list_spec.rb
+++ b/spec/acceptance/create_detailed_list_spec.rb
@@ -16,7 +16,7 @@ describe "create multiple detailed instances" do
 
   context "with singular value for details" do
     subject { FactoryGirl.create_detailed_list(:post, 5, 
-                                               title: ["Into the White Yonder"]) }
+                                               titles: ["Into the White Yonder"]) }
     
     its(:length) { should eq 5 }
 
@@ -43,7 +43,7 @@ describe "create multiple detailed instances" do
 
   context "with multiple values for details" do
     subject { FactoryGirl.create_detailed_list(:post, 20, 
-                                 title: [ "Into the White Yonder", 
+                                 titles: [ "Into the White Yonder", 
                                           "Into the Yellow Yonder", 
                                           "Into the ... I don't know - Purple? Yonder"]) }
     
@@ -62,12 +62,26 @@ describe "create multiple detailed instances" do
     end
   end
 
+  context "with both an array and a normal value" do
+    subject { FactoryGirl.create_detailed_list(:post, 20, title: "Into the Yellow Yonder", titles: [ "Into the Black Yonder"]) }
+
+    it "overrides the first post" do
+      expect(subject.first.title).to eq "Into the Black Yonder"
+    end
+
+    it "overrides the value of the remaining posts" do
+      subject[1..-1].each do |record|
+        expect(record.title).to eq "Into the Yellow Yonder"
+      end
+    end
+  end
+
   context "with multiple attributes and singular values" do
     subject { FactoryGirl.create_detailed_list(:post, 20, 
-                                  title: [ "Into the White Yonder", 
+                                  titles: [ "Into the White Yonder", 
                                            "Into the Yellow Yonder", 
                                            "Into the ... I don't know - Purple? Yonder"],
-                                  author: [ "Frank's distant cousin", 
+                                  authors: [ "Frank's distant cousin", 
                                             "James the Third, or Fourth" ]) }
   
     it "overrides all provided attributes" do
@@ -83,7 +97,7 @@ describe "create multiple detailed instances" do
 
   context "with a block" do
     subject do
-      FactoryGirl.create_detailed_list(:post, 20, title: ["Into the Block"]) do |post|
+      FactoryGirl.create_detailed_list(:post, 20, titles: ["Into the Block"]) do |post|
         post.position = post.id
       end
     end
@@ -98,7 +112,7 @@ describe "create multiple detailed instances" do
   context "with override for all values" do
     subject do
       FactoryGirl.create_detailed_list( :post, 5, 
-                                        title: ["Into the Black Yonder"] , 
+                                        titles: ["Into the Black Yonder"] , 
                                         author: "Frank")
     end
     

--- a/spec/acceptance/create_detailed_list_spec.rb
+++ b/spec/acceptance/create_detailed_list_spec.rb
@@ -76,6 +76,16 @@ describe "create multiple detailed instances" do
     end
   end
 
+  context "with a higher number specified than the actual number of records" do
+    subject { FactoryGirl.create_detailed_list(:post, 1, titles: [ "Into the Black Yonder", "Into the Maroon Yonder"]) }
+  
+    its(:length) { should eq 1 }
+
+    it "overrides the first post" do
+      expect(subject.first.title).to eq "Into the Black Yonder"
+    end
+  end
+
   context "with multiple attributes and singular values" do
     subject { FactoryGirl.create_detailed_list(:post, 20, 
                                   titles: [ "Into the White Yonder", 
@@ -168,3 +178,4 @@ describe "multiple creates and transient attributes to dynamically build attribu
     expect(FactoryGirl.create(:user_with_posts, posts_count: 2).posts.length).to eq 2
   end
 end
+

--- a/spec/acceptance/create_detailed_list_spec.rb
+++ b/spec/acceptance/create_detailed_list_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "create multiple detailed instances" do
+  before do
+    define_model('Post', title: :string, position: :integer)
+  
+
+    FactoryGirl.define do
+      factory(:post) do |post|
+        post.title "Into the Blue Yonder"
+        post.position { rand(10**4) }
+      end
+    end
+  end
+
+  context "with singular detail hash" do
+    subject { FactoryGirl.create_detailed_list(:post, 20, {title: ['Into the White Yonder']}) }
+    
+    its(:length) { should eq 20 }
+
+    it "creates all the posts" do
+      subject.each do |record|
+        expect(record).not_to be_new_record
+      end
+    end
+
+  end
+end

--- a/spec/acceptance/create_detailed_list_spec.rb
+++ b/spec/acceptance/create_detailed_list_spec.rb
@@ -2,21 +2,23 @@ require 'spec_helper'
 
 describe "create multiple detailed instances" do
   before do
-    define_model('Post', title: :string, position: :integer)
+    define_model('Post', title: :string, author: :string, position: :integer)
   
 
     FactoryGirl.define do
       factory(:post) do |post|
         post.title "Into the Blue Yonder"
+        post.author "High Lord Frank of the Summer Isles"
         post.position { rand(10**4) }
       end
     end
   end
 
-  context "with singular detail hash" do
-    subject { FactoryGirl.create_detailed_list(:post, 20, {title: ['Into the White Yonder']}) }
+  context "with singular value for details" do
+    subject { FactoryGirl.create_detailed_list(:post, 5, 
+                                               title: ["Into the White Yonder"]) }
     
-    its(:length) { should eq 20 }
+    its(:length) { should eq 5 }
 
     it "creates all the posts" do
       subject.each do |record|
@@ -24,5 +26,131 @@ describe "create multiple detailed instances" do
       end
     end
 
+    it "overrides the value for the provided attribute for the first post" do
+      expect(subject.first.title).to eq "Into the White Yonder"
+    end
+
+    it "only overrides the first post in the list" do
+      subject[1..-1].each do |record|
+        expect(record.title).to eq "Into the Blue Yonder"
+      end
+    end
+
+    it "only overrides the provided attribute in the details hash" do
+      expect(subject.first.author).to eq "High Lord Frank of the Summer Isles"
+    end
+  end
+
+  context "with multiple values for details" do
+    subject { FactoryGirl.create_detailed_list(:post, 20, 
+                                 title: [ "Into the White Yonder", 
+                                          "Into the Yellow Yonder", 
+                                          "Into the ... I don't know - Purple? Yonder"]) }
+    
+    it "overrides values for the second post" do
+      expect(subject.second.title).to eq "Into the Yellow Yonder"
+    end
+    
+    it "overrides values for the third post" do
+      expect(subject.third.title).to eq "Into the ... I don't know - Purple? Yonder"
+    end
+
+    it "leaves the remaining posts alone" do
+      subject[3..-1].each do |record|
+        expect(record.title).to eq "Into the Blue Yonder"
+      end
+    end
+  end
+
+  context "with multiple attributes and singular values" do
+    subject { FactoryGirl.create_detailed_list(:post, 20, 
+                                  title: [ "Into the White Yonder", 
+                                           "Into the Yellow Yonder", 
+                                           "Into the ... I don't know - Purple? Yonder"],
+                                  author: [ "Frank's distant cousin", 
+                                            "James the Third, or Fourth" ]) }
+  
+    it "overrides all provided attributes" do
+      expect(subject.first.title).to eq "Into the White Yonder"
+      expect(subject.first.author).to eq "Frank's distant cousin"
+    end
+
+    it "doesn't override when the provided attribute has no value" do
+      expect(subject.third.title).to eq "Into the ... I don't know - Purple? Yonder"
+      expect(subject.third.author).to eq "High Lord Frank of the Summer Isles"
+    end
+  end
+
+  context "with a block" do
+    subject do
+      FactoryGirl.create_detailed_list(:post, 20, title: ["Into the Block"]) do |post|
+        post.position = post.id
+      end
+    end
+
+    it "uses the new values" do
+      subject.each_with_index do |record, index|
+        expect(record.position).to eq record.id
+      end
+    end
+  end
+
+  context "with override for all values" do
+    subject do
+      FactoryGirl.create_detailed_list( :post, 5, 
+                                        title: ["Into the Black Yonder"] , 
+                                        author: "Frank")
+    end
+    
+    it "overides all values with the provided secondary hash" do
+      expect(subject.first.title).to eq "Into the Black Yonder"
+      expect(subject.first.author).to eq "Frank"
+      
+      subject[1..-1].each do |record|
+        expect(record.title).to eq "Into the Blue Yonder"
+        expect(record.author).to eq "Frank"
+      end
+    end
+  end
+end
+
+describe "multiple creates and transient attributes to dynamically build attribute lists" do
+  before do
+    define_model('User', name: :string) do
+      has_many :posts
+    end
+
+    define_model('Post', title: :string, user_id: :integer) do
+      belongs_to :user
+    end
+
+    FactoryGirl.define do 
+      factory :post do
+        title "Into the Blue Yonder"
+        user
+      end
+
+      factory :user do
+        name "Frank"
+        
+        factory :user_with_posts do
+          transient do 
+            posts_count 5
+          end
+        
+          after(:create) do |user, evaluator|
+            FactoryGirl.create_detailed_list(:post, evaluator.posts_count, user: user)
+          end
+        end
+      end
+    end
+  end
+
+  it "generates the correct number of posts" do
+    expect(FactoryGirl.create(:user_with_posts).posts.length).to eq 5 
+  end
+ 
+  it "allows the number of posts to be modified" do
+    expect(FactoryGirl.create(:user_with_posts, posts_count: 2).posts.length).to eq 2
   end
 end

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -284,6 +284,23 @@ describe "traits added via strategy" do
       end
     end
   end
+  
+  context "adding traits in create_detailed_list" do
+    subject { FactoryGirl.create_detailed_list(:user, 4, :great, :admin, name: ["Ford", "Arthur"]) }
+
+    its(:length) { should eq 4 }
+    
+    it "creates all records" do
+      subject.each do |record|
+        expect(record.admin).to be_true
+      end
+    end
+
+    it "sets the attributes for the specified records" do
+      expect(subject.first.name).to eq "FORD"
+      expect(subject.second.name).to eq "ARTHUR"
+    end
+  end
 
   context "adding traits in build_list" do
     subject { FactoryGirl.build_list(:user, 2, :admin, :great, name: "Joe") }


### PR DESCRIPTION
In order to add certain specific attributes for a designated amount of records, one can now specify an array of values for an attribute (in addition to the regular way of defining traits and attributes), and the first `n` records (where `n` is the length of the array) will have their specified attributes overwritten by the values in the provided array.

For instance, if one wanted to create 5 users whom all have the `admin` trait, and want to name the first *three* users `Tim`, `Frank` and `Ted`, then this could be accomplished like so:

```ruby
create_detailed_list(:user, 5, :admin, names: ['Tim', 'Frank', 'Ted'])
```

There's more detailes in the `GETTING_STARTED` document.

I've added specs for the new method, though there might be some edge cases that I have not thought of. Also, the method body of `create_detailed_list` could probably look better, but I haven't been able to think of a way to improve it.