### PR TITLE
updates getting_started to require factory_girl_rails

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -31,6 +31,7 @@ Configure your test suite
 ```ruby
 # RSpec
 # spec/support/factory_girl.rb
+require 'factory_girl_rails'
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 end


### PR DESCRIPTION
I ran into `uninitialized constant FactoryGirl (NameError)` when referencing the documentation, and noted in a [stack overflow](http://stackoverflow.com/questions/22715519/having-trouble-with-rspec-testing-uninitialized-constant-factorygirl-name-erro) the fix. 

Is there actually not normally a need for this, and the require is an edgecase? if so, then i can adjust to note that you may need it instead of saying its required. 