### PR TITLE
Cache Bundler on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ gemfile:
 branches:
   only:
     - master
+
+sudo: false
+cache: bundler


### PR DESCRIPTION
http://docs.travis-ci.com/user/workers/container-based-infrastructure/

With Container based CI, public projects can cache the results of bundle 
install