### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.1.0
   - 2.2.2
   - jruby-19mode
+  - rbx-2
 before_install:
   - gem update --system
 install: "bundle install"


### PR DESCRIPTION
Adding Rubinius to build matrix to verify that FactoryGirl works on Rubinius. I would appreciate if you could add this to your build matrix so we can ensure FactoryGirl works on Rubinius. Thank you.