### PR TITLE
Use parent strategy when building associations

### DIFF
--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -60,9 +60,12 @@ module FactoryGirl
   end
 
   class << self
-    delegate :factories, :sequences, :traits, :callbacks, :strategies, :callback_names,
-      :to_create, :skip_create, :initialize_with, :constructor, :duplicate_attribute_assignment_from_initialize_with,
-      :duplicate_attribute_assignment_from_initialize_with=, to: :configuration
+    delegate :factories, :sequences, :traits, :callbacks, :strategies,
+             :callback_names, :use_parent_strategy, :to_create, :skip_create,
+             :initialize_with, :constructor,
+             :duplicate_attribute_assignment_from_initialize_with,
+             :duplicate_attribute_assignment_from_initialize_with=,
+             to: :configuration
   end
 
   def self.register_factory(factory)
@@ -125,6 +128,10 @@ module FactoryGirl
   def self.register_callback(name)
     name = name.to_sym
     callback_names << name
+  end
+
+  def self.use_parent_strategy=(value)
+    configuration.use_parent_strategy = value
   end
 end
 

--- a/lib/factory_girl/configuration.rb
+++ b/lib/factory_girl/configuration.rb
@@ -3,6 +3,8 @@ module FactoryGirl
   class Configuration
     attr_reader :factories, :sequences, :traits, :strategies, :callback_names
 
+    attr_accessor :use_parent_strategy
+
     def initialize
       @factories      = Decorator::DisallowsDuplicatesRegistry.new(Registry.new('Factory'))
       @sequences      = Decorator::DisallowsDuplicatesRegistry.new(Registry.new('Sequence'))

--- a/lib/factory_girl/evaluator.rb
+++ b/lib/factory_girl/evaluator.rb
@@ -23,7 +23,13 @@ module FactoryGirl
 
     def association(factory_name, *traits_and_overrides)
       overrides = traits_and_overrides.extract_options!
-      strategy_override = overrides.fetch(:strategy) { :create }
+      strategy_override = overrides.fetch(:strategy) do
+        if FactoryGirl.use_parent_strategy
+          @build_strategy.class
+        else
+          :create
+        end
+      end
 
       traits_and_overrides += [overrides.except(:strategy)]
 

--- a/spec/acceptance/build_spec.rb
+++ b/spec/acceptance/build_spec.rb
@@ -27,9 +27,16 @@ describe "a built instance" do
     expect(subject.user).to be_kind_of(User)
     expect(subject.user).not_to be_new_record
   end
+
+  it "assigns but does not save associations when using parent strategy" do
+    FactoryGirl.use_parent_strategy = true
+
+    expect(subject.user).to be_kind_of(User)
+    expect(subject.user).to be_new_record
+  end
 end
 
-describe "a built instance with strategy: :build" do
+describe "a built instance with strategy: :create" do
   include FactoryGirl::Syntax::Methods
 
   before do
@@ -43,7 +50,7 @@ describe "a built instance with strategy: :build" do
       factory :user
 
       factory :post do
-        association(:user, strategy: :build)
+        association(:user, strategy: :create)
       end
     end
   end
@@ -52,9 +59,9 @@ describe "a built instance with strategy: :build" do
 
   it { should be_new_record }
 
-  it "assigns but does not save associations" do
+  it "assigns and saves associations" do
     expect(subject.user).to be_kind_of(User)
-    expect(subject.user).to be_new_record
+    expect(subject.user).not_to be_new_record
   end
 end
 

--- a/spec/acceptance/register_strategies_spec.rb
+++ b/spec/acceptance/register_strategies_spec.rb
@@ -100,10 +100,18 @@ describe "associations without overriding :strategy" do
     end
   end
 
-  it "uses the overridden create strategy to create the association" do
+  it "uses the overridden strategy on the association" do
     FactoryGirl.register_strategy(:create, custom_strategy)
     post = FactoryGirl.build(:post)
     expect(post.user.name).to eq "Custom strategy"
+  end
+
+  it "uses the parent strategy to build the association when flag set" do
+    FactoryGirl.register_strategy(:create, custom_strategy)
+    FactoryGirl.use_parent_strategy = true
+
+    post = FactoryGirl.build(:post)
+    expect(post.user.name).to eq "John Doe"
   end
 end
 


### PR DESCRIPTION
This PR makes associations be created using the same strategy as their parent. i.e. if a Post has a User association and we build a Post, we should build a User as well - not create it.

#### Background

The source of this behaviour seems to go back to [this gist](https://gist.github.com/jferris/569231).

There's a bit of discussion on #64 and #66, but then it seems to fall off the map a bit when the option to explicitly name a strategy is added.

#### Motivation

The main project I'm on at the moment has a fairly deep association chain. We use build_stubbed where possible, but find that we need to duplicate a lot of setup because after(:build) traits don't run with build_stubbed. At times, we're hitting the DB 5 times for associated creates for a single insert.

When looking into why we were hitting into the DB at all when building factories, I came across a number of other blog posts and pull requests of confused people. This does seem like confusing behaviour to most and the particular use case in the gist seems arguably incorrect - Post should probably validate _user_ is present, and if it really does want to validate _user_id_ then the factory should either set that or use create explicitly.

#### Results

I've struggled to find public codebases using factory girl a lot - please point me to any if you know of them.

Pending that info, I've tried this on private projects and have seen non-js suites drop by ~ 60% with no changes or failures.

### Summary

So.... the situation seems to be:

Cons:
- This *might* break things for people relying on (arguably) broken validates_presence_of foreign_key tests

Pros:
- This *should* speed things up for people using build and associations
- This makes the build association behaviour much less surprising

All those changes are pretty hard to quantify, so I totally understand if it's not a change you think it worth the risk. No harm in raising the discussion though, right? :-) Thanks for reading!