### PR TITLE
Fix warnings

### DIFF
--- a/lib/factory_girl/definition_proxy.rb
+++ b/lib/factory_girl/definition_proxy.rb
@@ -54,7 +54,7 @@ module FactoryGirl
     def ignore(&block)
       ActiveSupport::Deprecation.warn "`#ignore` is deprecated and will be "\
         "removed in 5.0. Please use `#transient` instead."
-      transient &block
+      transient(&block)
     end
 
     def transient(&block)

--- a/lib/factory_girl/linter.rb
+++ b/lib/factory_girl/linter.rb
@@ -15,9 +15,10 @@ module FactoryGirl
       end
     end
 
-    private
-
     attr_reader :factories_to_lint, :invalid_factories
+    private     :factories_to_lint, :invalid_factories
+
+    private
 
     def calculate_invalid_factories
       factories_to_lint.inject({}) do |result, factory|


### PR DESCRIPTION
Fix a couple of warnings generated when Ruby is run in verbose mode and the gem is required.