### PR TITLE
Make debugger friendly.

### DIFF
--- a/lib/factory_girl/definition_proxy.rb
+++ b/lib/factory_girl/definition_proxy.rb
@@ -96,9 +96,9 @@ module FactoryGirl
     # are equivalent.
     def method_missing(name, *args, &block)
       # If methods are called from debugger, original method should be called
-      if defined?(caller_locations) &&
+      if defined?(caller_locations) && (
         ['eval', 'process_commands', 'build_compact_name','build_compact_value_attr', 'print_element'].include?(caller_locations[1].base_label) ||
-        caller_locations[1].path == "(eval)"
+        caller_locations[1].path == "(eval)" )
         if methods.include?(("__orig__" + name.to_s).to_sym)
           m = method(("__orig__" + name.to_s).to_sym)
           return block ? m.call(*args, block) : m.call(*args)

--- a/lib/factory_girl/definition_proxy.rb
+++ b/lib/factory_girl/definition_proxy.rb
@@ -96,15 +96,16 @@ module FactoryGirl
     # are equivalent.
     def method_missing(name, *args, &block)
       # If methods are called from debugger, original method should be called
-      if ['eval', 'process_commands', 'build_compact_name', 'build_compact_value_attr', 'print_element'].include?(caller_locations[1].base_label) ||
-          caller_locations[1].path == "(eval)" then
-          if methods.include?(("__orig__" + name.to_s).to_sym)
-              m = method(("__orig__" + name.to_s).to_sym)
-              return block ? m.call(*args, block) : m.call(*args)
-          end
-          return
+      if defined?(caller_locations) &&
+        ['eval', 'process_commands', 'build_compact_name','build_compact_value_attr', 'print_element'].include?(caller_locations[1].base_label) ||
+        caller_locations[1].path == "(eval)"
+        if methods.include?(("__orig__" + name.to_s).to_sym)
+          m = method(("__orig__" + name.to_s).to_sym)
+          return block ? m.call(*args, block) : m.call(*args)
+        end
+        return
       end
-      
+
       if args.empty? && block.nil?
         @definition.declare_attribute(Declaration::Implicit.new(name, @definition, @ignore))
       elsif args.first.respond_to?(:has_key?) && args.first.has_key?(:factory)

--- a/lib/factory_girl/definition_proxy.rb
+++ b/lib/factory_girl/definition_proxy.rb
@@ -96,9 +96,9 @@ module FactoryGirl
     # are equivalent.
     def method_missing(name, *args, &block)
       # If methods are called from debugger, original method should be called
-      if defined?(caller_locations) && (
-        ['eval', 'process_commands', 'build_compact_name','build_compact_value_attr', 'print_element'].include?(caller_locations[1].base_label) ||
-        caller_locations[1].path == "(eval)" )
+      if defined?(caller_locations) &&
+        (['eval', 'process_commands', 'build_compact_name','build_compact_value_attr', 'print_element'].include?(caller_locations[1].base_label) ||
+        caller_locations[1].path == "(eval)")
         if methods.include?(("__orig__" + name.to_s).to_sym)
           m = method(("__orig__" + name.to_s).to_sym)
           return block ? m.call(*args, block) : m.call(*args)


### PR DESCRIPTION
When debugger's break points are set at FactoryGirl, FactoryGirl does not
work but show error like below.
 "FactoryGirl::AttributeDefinitionError: Attribute already defined: is_a?"
At breakpoint, debugger tried to show variables but FactoryGirl defines
all unknown methods that may be called from debbuger that cause trouble.
This commit changes method_missing to call DefinitionProxy's original method
or just return when methods are called from debugger.