### PR TITLE
Add info to notification's payload

### DIFF
--- a/lib/factory_girl/factory_runner.rb
+++ b/lib/factory_girl/factory_runner.rb
@@ -17,7 +17,7 @@ module FactoryGirl
         factory = factory.with_traits(@traits)
       end
 
-      instrumentation_payload = { name: @name, strategy: runner_strategy }
+      instrumentation_payload = { name: @name, strategy: runner_strategy, factory: factory }
 
       ActiveSupport::Notifications.instrument('factory_girl.run_factory', instrumentation_payload) do
         factory.run(runner_strategy, @overrides, &block)

--- a/lib/factory_girl/factory_runner.rb
+++ b/lib/factory_girl/factory_runner.rb
@@ -17,8 +17,13 @@ module FactoryGirl
         factory = factory.with_traits(@traits)
       end
 
-      instrumentation_payload = { name: @name, strategy: runner_strategy, traits: @traits,
-         overrides: @overrides, factory: factory }
+      instrumentation_payload = {  
+        name: @name,
+        strategy: runner_strategy,
+        traits: @traits,
+        overrides: @overrides,
+        factory: factory
+      }
 
       ActiveSupport::Notifications.instrument('factory_girl.run_factory', instrumentation_payload) do
         factory.run(runner_strategy, @overrides, &block)

--- a/lib/factory_girl/factory_runner.rb
+++ b/lib/factory_girl/factory_runner.rb
@@ -17,7 +17,7 @@ module FactoryGirl
         factory = factory.with_traits(@traits)
       end
 
-      instrumentation_payload = {  
+      instrumentation_payload = {
         name: @name,
         strategy: runner_strategy,
         traits: @traits,

--- a/lib/factory_girl/factory_runner.rb
+++ b/lib/factory_girl/factory_runner.rb
@@ -17,7 +17,8 @@ module FactoryGirl
         factory = factory.with_traits(@traits)
       end
 
-      instrumentation_payload = { name: @name, strategy: runner_strategy, traits: @traits, overrides: @overrides, factory: factory }
+      instrumentation_payload = { name: @name, strategy: runner_strategy, traits: @traits,
+         overrides: @overrides, factory: factory }
 
       ActiveSupport::Notifications.instrument('factory_girl.run_factory', instrumentation_payload) do
         factory.run(runner_strategy, @overrides, &block)

--- a/lib/factory_girl/factory_runner.rb
+++ b/lib/factory_girl/factory_runner.rb
@@ -17,7 +17,7 @@ module FactoryGirl
         factory = factory.with_traits(@traits)
       end
 
-      instrumentation_payload = { name: @name, strategy: runner_strategy, factory: factory }
+      instrumentation_payload = { name: @name, strategy: runner_strategy, traits: @traits, overrides: @overrides, factory: factory }
 
       ActiveSupport::Notifications.instrument('factory_girl.run_factory', instrumentation_payload) do
         factory.run(runner_strategy, @overrides, &block)

--- a/spec/acceptance/activesupport_instrumentation_spec.rb
+++ b/spec/acceptance/activesupport_instrumentation_spec.rb
@@ -58,7 +58,10 @@ describe "using ActiveSupport::Instrumentation to track factory interaction" do
       FactoryGirl.attributes_for(:slow_user)
     end
 
-    expect(tracked_invocations[:slow_user]).to eq(build: 2, attributes_for: 1, factory:FactoryGirl.factory_by_name("slow_user"))
-    expect(tracked_invocations[:user]).to eq(build: 5, create: 2, factory:FactoryGirl.factory_by_name("user"))
+    expect(tracked_invocations[:slow_user][:build]).to eq(2)
+    expect(tracked_invocations[:slow_user][:attributes_for]).to eq(1)
+    expect(tracked_invocations[:slow_user][:factory]).to eq(FactoryGirl.factory_by_name("slow_user"))
+    expect(tracked_invocations[:user][:build]).to eq(5)
+    expect(tracked_invocations[:user][:factory]).to eq(FactoryGirl.factory_by_name("user"))
   end
 end

--- a/spec/acceptance/activesupport_instrumentation_spec.rb
+++ b/spec/acceptance/activesupport_instrumentation_spec.rb
@@ -44,9 +44,11 @@ describe "using ActiveSupport::Instrumentation to track factory interaction" do
     callback = ->(name, start, finish, id, payload) do
       factory_name = payload[:name]
       strategy_name = payload[:strategy]
+      factory = payload[:factory]
       tracked_invocations[factory_name] ||= {}
       tracked_invocations[factory_name][strategy_name] ||= 0
       tracked_invocations[factory_name][strategy_name] += 1
+      tracked_invocations[factory_name][:factory] = factory
     end
 
     ActiveSupport::Notifications.subscribed(callback, "factory_girl.run_factory") do
@@ -56,7 +58,7 @@ describe "using ActiveSupport::Instrumentation to track factory interaction" do
       FactoryGirl.attributes_for(:slow_user)
     end
 
-    expect(tracked_invocations[:slow_user]).to eq(build: 2, attributes_for: 1)
-    expect(tracked_invocations[:user]).to eq(build: 5, create: 2)
+    expect(tracked_invocations[:slow_user]).to eq(build: 2, attributes_for: 1, factory:FactoryGirl.factory_by_name("slow_user"))
+    expect(tracked_invocations[:user]).to eq(build: 5, create: 2, factory:FactoryGirl.factory_by_name("user"))
   end
 end

--- a/spec/acceptance/activesupport_instrumentation_spec.rb
+++ b/spec/acceptance/activesupport_instrumentation_spec.rb
@@ -14,6 +14,8 @@ unless ActiveSupport::Notifications.respond_to?(:subscribed)
 end
 
 describe "using ActiveSupport::Instrumentation to track factory interaction" do
+  let(:slow_user_factory) { FactoryGirl.factory_by_name("slow_user") }
+  let(:user_factory) { FactoryGirl.factory_by_name("user") }
   before do
     define_model("User", email: :string)
     FactoryGirl.define do
@@ -60,8 +62,8 @@ describe "using ActiveSupport::Instrumentation to track factory interaction" do
 
     expect(tracked_invocations[:slow_user][:build]).to eq(2)
     expect(tracked_invocations[:slow_user][:attributes_for]).to eq(1)
-    expect(tracked_invocations[:slow_user][:factory]).to eq(FactoryGirl.factory_by_name("slow_user"))
+    expect(tracked_invocations[:slow_user][:factory]).to eq(slow_user_factory)
     expect(tracked_invocations[:user][:build]).to eq(5)
-    expect(tracked_invocations[:user][:factory]).to eq(FactoryGirl.factory_by_name("user"))
+    expect(tracked_invocations[:user][:factory]).to eq(user_factory)
   end
 end


### PR DESCRIPTION
Thank you for this useful gem very much. It always help me with my work.
Well, I wanted to know the detailed information of more executed factory.  Example at `GETTING_STARTED.md `, give me factory name, execution time , and stragy. However, I want to get more details infos. for example traits, association, ... etc.
 
So when I read code,I found factory_runner can access `@traits, @overrides`, and `factory`object. These data help my testing to more effective.

I think there is no reason not to add these data to payload. Please consider this pr.
Finally, I'm sorry my poor English... 