### PR TITLE
Update docs on associations

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -257,7 +257,7 @@ post = create(:post)
 post.new_record?        # => false
 post.author.new_record? # => false
 
-# Builds and saves a User, and then builds but does not save a Post
+# Builds and saves a Post, and then builds but does not save a User
 post = build(:post)
 post.new_record?        # => true
 post.author.new_record? # => false


### PR DESCRIPTION
According to the example given, the `User` record is the one that is not persisted, not the `Post`