### PR TITLE
Undef possible method before defining

### DIFF
--- a/lib/factory_girl/evaluator.rb
+++ b/lib/factory_girl/evaluator.rb
@@ -64,6 +64,10 @@ module FactoryGirl
     end
 
     def self.define_attribute(name, &block)
+      if method_defined?(name) || private_method_defined?(name)
+        undef_method(name)
+      end
+
       define_method(name) do
         if @cached_attributes.key?(name)
           @cached_attributes[name]

--- a/lib/factory_girl/strategy_syntax_method_registrar.rb
+++ b/lib/factory_girl/strategy_syntax_method_registrar.rb
@@ -39,6 +39,10 @@ module FactoryGirl
 
     def define_syntax_method(name, &block)
       FactoryGirl::Syntax::Methods.module_exec do
+        if method_defined?(name) || private_method_defined?(name)
+          undef_method(name)
+        end
+
         define_method(name, &block)
       end
     end


### PR DESCRIPTION
Without these changes, factory_girl causes massive number of Ruby :warning:s as follows when run with `--warning` flag:

> warning: method redefined; discarding old ...
> warning: previous definition of ... was here