### PR TITLE
Fix typo in GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -838,7 +838,7 @@ will negatively impact the performance
 of your tests
 when running single tests.
 
-Example Rask task:
+Example Rake task:
 
 ```ruby
 # lib/tasks/factory_girl.rake


### PR DESCRIPTION
Changed "Rask" in favor of "Rake". Almost unnoticeable :)