### PR TITLE
port test suite to rspec3

### DIFF
--- a/factory_girl.gemspec
+++ b/factory_girl.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency("activesupport", ">= 3.0.0")
 
-  s.add_development_dependency("rspec",    "~> 2.12.0")
+  s.add_development_dependency("rspec",    "~> 3.0")
+  s.add_development_dependency("rspec-its", "~> 1.0")
   s.add_development_dependency("cucumber", "~> 1.3.15")
   s.add_development_dependency("timecop")
   s.add_development_dependency("simplecov")

--- a/spec/acceptance/modify_factories_spec.rb
+++ b/spec/acceptance/modify_factories_spec.rb
@@ -134,7 +134,7 @@ describe "modifying factories" do
 
         its(:name)  { should eq "Great User" }
         its(:email) { should eq "Great User-modified@example.com" }
-        its(:admin) { should be_true }
+        its(:admin) { should be true }
       end
 
       context "overriding dynamic attributes" do
@@ -142,7 +142,7 @@ describe "modifying factories" do
 
         its(:name)  { should eq "Great User" }
         its(:email) { should eq "perfect@example.com" }
-        its(:admin) { should be_true }
+        its(:admin) { should be true }
       end
 
       context "overriding static attributes" do
@@ -150,7 +150,7 @@ describe "modifying factories" do
 
         its(:name)  { should eq "wonderful" }
         its(:email) { should eq "wonderful-modified@example.com" }
-        its(:admin) { should be_true }
+        its(:admin) { should be true }
       end
     end
   end

--- a/spec/acceptance/sequence_context_spec.rb
+++ b/spec/acceptance/sequence_context_spec.rb
@@ -38,7 +38,7 @@ describe 'sequences are evaluated in the correct context' do
       end
     end
 
-    expect(FactoryGirl.build(:sequence_with_frozen).id).to be_false
+    expect(FactoryGirl.build(:sequence_with_frozen).id).to be false
   end
 
   it 'allows direct reference of a method in a sequence' do

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -241,7 +241,7 @@ describe "traits added via strategy" do
   context "adding traits in create" do
     subject { FactoryGirl.create(:user, :admin, :great, name: "Joe") }
 
-    its(:admin) { should be_true }
+    its(:admin) { should be true }
     its(:name)  { should eq "JOE" }
 
     it "doesn't modify the user factory" do
@@ -254,21 +254,21 @@ describe "traits added via strategy" do
   context "adding traits in build" do
     subject { FactoryGirl.build(:user, :admin, :great, name: "Joe") }
 
-    its(:admin) { should be_true }
+    its(:admin) { should be true }
     its(:name)  { should eq "Joe" }
   end
 
   context "adding traits in attributes_for" do
     subject { FactoryGirl.attributes_for(:user, :admin, :great) }
 
-    its([:admin]) { should be_true }
+    its([:admin]) { should be true }
     its([:name])  { should eq "John" }
   end
 
   context "adding traits in build_stubbed" do
     subject { FactoryGirl.build_stubbed(:user, :admin, :great, name: "Jack") }
 
-    its(:admin) { should be_true }
+    its(:admin) { should be true }
     its(:name)  { should eq "Jack" }
   end
 
@@ -279,7 +279,7 @@ describe "traits added via strategy" do
 
     it "creates all the records" do
       subject.each do |record|
-        expect(record.admin).to be_true
+        expect(record.admin).to be true
         expect(record.name).to eq "JOE"
       end
     end
@@ -292,7 +292,7 @@ describe "traits added via strategy" do
 
     it "builds all the records" do
       subject.each do |record|
-        expect(record.admin).to be_true
+        expect(record.admin).to be true
         expect(record.name).to eq "Joe"
       end
     end

--- a/spec/factory_girl/find_definitions_spec.rb
+++ b/spec/factory_girl/find_definitions_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-share_examples_for "finds definitions" do
+shared_examples_for "finds definitions" do
   before do
     FactoryGirl.stubs(:load)
     FactoryGirl.find_definitions

--- a/spec/factory_girl/strategy/create_spec.rb
+++ b/spec/factory_girl/strategy/create_spec.rb
@@ -20,6 +20,6 @@ describe FactoryGirl::Strategy::Create do
     evaluation = evaluation_class.new
     evaluation.stubs(object: nil, notify: nil)
     subject.result(evaluation)
-    expect(evaluation.block_run).to be_true
+    expect(evaluation.block_run).to be true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH << File.join(File.dirname(__FILE__))
 require 'rubygems'
 require 'rspec'
 require 'rspec/autorun'
+require 'rspec/its'
 
 require "simplecov"
 


### PR DESCRIPTION
This this a slight change of the specs to be able to run them with RSpec v3.
This commit also bumps the version of rspec in the gemspec file and adds a dependency on rspec-its.