### PR TITLE
Raise an error when a sequence returns a value that is less than the last value

### DIFF
--- a/lib/factory_girl/errors.rb
+++ b/lib/factory_girl/errors.rb
@@ -11,6 +11,9 @@ module FactoryGirl
   # Raised when attempting to register a sequence from a dynamic attribute block
   class SequenceAbuseError < RuntimeError; end
 
+  # Raised when the next value in a sequence is < the previous value (e.g. "z" < "aa" or "9" < "10")
+  class SequenceOverflowError < RuntimeError; end
+
   # Raised when defining an invalid attribute:
   # * Defining an attribute which has a name ending in "="
   # * Defining an attribute with both a static and lazy value

--- a/spec/factory_girl/sequence_spec.rb
+++ b/spec/factory_girl/sequence_spec.rb
@@ -12,6 +12,12 @@ describe FactoryGirl::Sequence do
     describe "when incrementing" do
       before     { subject.next }
       its(:next) { should eq "=2" }
+
+      describe "when incrementing when the next value is < the previous" do
+        it "raises an error" do
+          expect { 10.times { subject.next } }.to raise_error(FactoryGirl::SequenceOverflowError)
+        end
+      end
     end
   end
 
@@ -22,6 +28,12 @@ describe FactoryGirl::Sequence do
     describe "when incrementing" do
       before     { subject.next }
       its(:next) { should eq "=B" }
+    end
+
+    describe "when incrementing when the next value is < the previous" do
+      it "raises an error" do
+        expect { 27.times { subject.next } }.to raise_error(FactoryGirl::SequenceOverflowError)
+      end
     end
   end
 


### PR DESCRIPTION
The prime example is:

`sequence(:name) { |n| "name#{n}" }`

If your code evers sort by `name` alphabetically, then you could end up
with the case where your sequence returns `name9`, `name10`. The test
might pass in isolation, but when run as part of a full suite, you could
end up with intermittent failures based on the ordering of the specs.

This raises an error if a value is ever less than (`<`) the previous value.
The solution is to change your sequence to `sequence(:name, "00000000")`
(or some longer string if you call the sequence several millions of times).

If you are using an enumerator, this check is skipped.

This could be considered a breaking change, so I am open to adding a configuration setting that issues a deprecation warning instead of raising an error as the default behavior. This addresses my issue #821. I have an alternative that I will issue a PR for that adds a new type of sequence that has this behavior without changing how `sequence` currently works.