### PR TITLE
Fix getting started for minitest

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -48,18 +48,18 @@ class Spinach::FeatureSteps
   include FactoryGirl::Syntax::Methods
 end
 
-# MiniTest
-class MiniTest::Unit::TestCase
+# Minitest
+class Minitest::Unit::TestCase
   include FactoryGirl::Syntax::Methods
 end
 
-# MiniTest::Spec
-class MiniTest::Spec
+# Minitest::Spec
+class Minitest::Spec
   include FactoryGirl::Syntax::Methods
 end
 
 # minitest-rails
-class MiniTest::Rails::ActiveSupport::TestCase
+class Minitest::Rails::ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
 end
 ```

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -57,11 +57,6 @@ end
 class Minitest::Spec
   include FactoryGirl::Syntax::Methods
 end
-
-# minitest-rails
-class Minitest::Rails::ActiveSupport::TestCase
-  include FactoryGirl::Syntax::Methods
-end
 ```
 
 If you do not include `FactoryGirl::Syntax::Methods` in your test suite, then all factory_girl methods will need to be prefaced with `FactoryGirl`.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -57,6 +57,11 @@ end
 class Minitest::Spec
   include FactoryGirl::Syntax::Methods
 end
+
+# minitest-rails
+class ActiveSupport::TestCase
+  include FactoryGirl::Syntax::Methods
+end
 ```
 
 If you do not include `FactoryGirl::Syntax::Methods` in your test suite, then all factory_girl methods will need to be prefaced with `FactoryGirl`.


### PR DESCRIPTION
I just tried to include the syntax methods in my project that uses `minitest-rails` and failed. Turns out there is no `MiniTest::Rails::ActiveSupport::TestCase` anymore. It works if I just include the methods in `Minitest::Spec` though, so I guess there is no need for an extra entry for `minitest-rails` anymore.
Also, I changed `MiniTest` to `Minitest`, which is the [preferred syntax](https://github.com/seattlerb/minitest/commit/9a57c520ceac76abfe6105866f8548a94eb357b6) since v5. (`MiniTest` still works but is an alias of `Minitest`).