### PR TITLE
Add space, make it easier for Opal to test

### DIFF
--- a/spec/acceptance/global_initialize_with_spec.rb
+++ b/spec/acceptance/global_initialize_with_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'global initialize_with' do
   before do
     define_class('User') do
-      attr_accessor:name
+      attr_accessor :name
 
       def initialize(name)
         @name = name


### PR DESCRIPTION
I know this isn't strictly broken on MRI, Rubinius, etc., but Opal's compiler doesn't like the lack of a space. If you could add it, that would be great. And it looks nice. :+1: 