### PR TITLE
Clear changed attributes with build_stubbed strategy

### DIFF
--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -10,6 +10,7 @@ module FactoryGirl
       def result(evaluation)
         evaluation.object.tap do |instance|
           stub_database_interaction_on_result(instance)
+          clear_changed_attributes_on_result(instance)
           evaluation.notify(:after_stub, instance)
         end
       end
@@ -67,6 +68,21 @@ module FactoryGirl
             end
           end
         end
+      end
+
+      def clear_changed_attributes_on_result(result_instance)
+        unless result_instance.respond_to?(:clear_changes_information)
+          result_instance.extend ActiveModelDirtyBackport
+        end
+
+        result_instance.clear_changes_information
+      end
+    end
+
+    module ActiveModelDirtyBackport
+      def clear_changes_information
+        @previously_changed = ActiveSupport::HashWithIndifferentAccess.new
+        @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
       end
     end
   end

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -51,6 +51,10 @@ describe "a generated stub instance" do
     expect(subject).not_to be_new_record
   end
 
+  it "isn't changed" do
+    expect(subject).not_to be_changed
+  end
+
   it "disables connection" do
     expect { subject.connection }.to raise_error(RuntimeError)
   end


### PR DESCRIPTION
Since `build_stubbed` returns an record that appears to be `persisted?`, I would expect there to be no changes tracked by `ActiveModel::Dirty`, but this is not currently the case as documented in #837. 

With these changes, `FactoryGirl::Strategy::Stub` will call `ActiveModel::Dirty#clear_changes_information` after stubbing database interaction on a result.