### PR TITLE
Find factories registered for namespaced models

### DIFF
--- a/lib/factory_girl/decorator/class_key_hash.rb
+++ b/lib/factory_girl/decorator/class_key_hash.rb
@@ -19,7 +19,7 @@ module FactoryGirl
         if key.respond_to?(:to_sym)
           key.to_sym
         else
-          key.to_s.underscore.to_sym
+          key.to_s.underscore.gsub("/", "_").to_sym
         end
       end
     end

--- a/spec/factory_girl/registry_spec.rb
+++ b/spec/factory_girl/registry_spec.rb
@@ -65,4 +65,13 @@ describe FactoryGirl::Registry do
     expect(subject.find(:user)).to eq registered_object
     expect(subject.find(User)).to eq registered_object
   end
+
+  it "registers namespaced classes" do
+    define_class("Invoice")
+    define_class("Invoice::Item")
+    subject.register(Invoice::Item, registered_object)
+    expect(subject.to_a).to eq [registered_object]
+    expect(subject.find(:invoice_item)).to eq registered_object
+    expect(subject.find(Invoice::Item)).to eq registered_object
+  end
 end


### PR DESCRIPTION
Namespaced models like `Invoice::Item` should be able to be found by `FactoryGirl.create(Invoice::Item)` if registered as `factory :invoice_item`.

I added a test for this new behavior.

Fixes #740