### PR TITLE
Remove Coaching section from README.md [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,6 @@ factory_girl was originally written by Joe Ferris and is now maintained by Josh
 Clayton. Many improvements and bugfixes were contributed by the [open source
 community](https://github.com/thoughtbot/factory_girl/graphs/contributors).
 
-Need Help?
-----------
-
-We offer 1-on-1 coaching. We can help you set up factory_girl, clean up your
-`factories.rb`, or speed up slow tests. [Get in touch].
-
 [Get in touch]: http://coaching.thoughtbot.com/rails/?utm_source=github
 
 License


### PR DESCRIPTION
Coaching on Rails is no longer available from Thoughtbot.

Addresses Issue #834