### PR TITLE
Update bundler before bundle install in travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - rbx-2
 before_install:
   - gem update --system
+  - gem update bundler
 install: "bundle install"
 script: "bundle exec rake spec:unit spec:acceptance features"
 jdk:


### PR DESCRIPTION
Travis CI Builds for `factory_girl` are broken because the `bundler` version that Travis CI automatically uses at this time (`1.7.6`) is coming across the following error/issue bundler/bundler#3558 that was fixed in a later version/release.

Having an outdated version of `bundler` in the Travis CI builds is an ongoing issue and this is currently the easiest work-around as seen in discussions at travis-ci/travis-ci#3531