### PR TITLE
Clarify file used to config Cucumber for Factory Girl syntax

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -41,7 +41,7 @@ class Test::Unit::TestCase
 end
 
 # Cucumber
-# env.rb (Rails example location - app/features/support/env.rb)
+# env.rb (Rails example location - RAILS_ROOT/features/support/env.rb)
 World(FactoryGirl::Syntax::Methods)
 
 # Spinach

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -41,6 +41,7 @@ class Test::Unit::TestCase
 end
 
 # Cucumber
+# env.rb (Rails example location - app/features/support/env.rb)
 World(FactoryGirl::Syntax::Methods)
 
 # Spinach


### PR DESCRIPTION
# A PR to help fellow BDD/TDD noobs

## Problem
I could not figure out where to add the designated Cucumber integration code for Factory Girl. Most tutorials seem to assume users will implicitly know this information.

## Solution
I finally found the correct location when visiting this tutorial: https://coderwall.com/p/kxfobg/taking-the-factorygirl-out-of-factorygirl-create.

## Request
Please consider adding this minor update to explicitly clarify which file the code is supposed to be added to. It may help other new developers avoid frustration.

Thanks!
Chris