### PR TITLE
Add how to assign values for JSON columns

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -162,6 +162,19 @@ factory :user do
 end
 ```
 
+JSON Properties
+---------------
+Because brackets `{ }` are interpretted first as a block for lazy attributes,
+if you need to assign a value to a model that has a property of type JSON
+you'll need to use double brackets `{{ }}` otherwise the value will be set to nil.
+
+```ruby
+factory :user do
+  # ...
+  json_property {{ :key => "value" }}
+end
+```
+
 Aliases
 -------
 


### PR DESCRIPTION
Not 100% sure where the best placement of this info would be, but made sense to me to include it right after lazy attributes since I mention the use of brackets related to that.