### PR TITLE
Don't package up specs and feature tests

### DIFF
--- a/factory_girl.gemspec
+++ b/factory_girl.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
                       using factories - less error-prone, more explicit, and
                       all-around easier to work with than fixtures.}
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(spec|features)/}) }
 
   s.require_path = 'lib'
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.2")


### PR DESCRIPTION
Tests aren't useful for end users of the gem, and excluding them from
the gem them reduces the size of the download.

Since bundler/bundler#3207 this has been the default for gems created
using `bundler gem`, and I've taken the code for excluding them from
there.