### PR TITLE
Update Travis build matrix to use CRuby on the appropriate Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ before_install:
   - gem update bundler
 install: "bundle install"
 script: "bundle exec rake"
-jdk:
-  - openjdk6
 gemfile:
   - gemfiles/3.2.gemfile
   - gemfiles/4.0.gemfile


### PR DESCRIPTION
Why?

JRuby takes significantly longer to run the test suite; this ensures
that we use MRI instead of JRuby as the wrapper when running non-JRuby.