### PR TITLE
Fix FactoryGirl::Decorator#send to pass blocks

### DIFF
--- a/lib/factory_girl/decorator.rb
+++ b/lib/factory_girl/decorator.rb
@@ -10,8 +10,8 @@ module FactoryGirl
       @component.send(name, *args, &block)
     end
 
-    def send(symbol, *args)
-      __send__(symbol, *args)
+    def send(symbol, *args, &block)
+      __send__(symbol, *args, &block)
     end
 
     def self.const_missing(name)

--- a/spec/acceptance/initialize_with_spec.rb
+++ b/spec/acceptance/initialize_with_spec.rb
@@ -215,3 +215,23 @@ describe "initialize_with has access to all attributes for construction" do
     expect(user_with_attributes.ignored).to be_nil
   end
 end
+
+describe "initialize_with for a constructor that requires a block" do
+  it "executes the block correctly" do
+    define_class("Awesome") do
+      attr_reader :output
+
+      def initialize(&block)
+        @output = instance_exec(&block)
+      end
+    end
+
+    FactoryGirl.define do
+      factory :awesome do
+        initialize_with { new { "Output" } }
+      end
+    end
+
+    expect(FactoryGirl.build(:awesome).output).to eq "Output"
+  end
+end


### PR DESCRIPTION
Why?

When the decorated @component is also a decorated object, and
FactoryGirl::Decorator#method_missing calls @component#send and a block
is present, the block needs to be sent appropriately.

Closes #816