### PR TITLE
Deprecate factory lookup by class

### DIFF
--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -69,8 +69,10 @@ module FactoryGirl
 
   class << self
     delegate :factories, :sequences, :traits, :callbacks, :strategies, :callback_names,
-      :to_create, :skip_create, :initialize_with, :constructor, :duplicate_attribute_assignment_from_initialize_with,
-      :duplicate_attribute_assignment_from_initialize_with=, to: :configuration
+             :to_create, :skip_create, :initialize_with, :constructor,
+             :duplicate_attribute_assignment_from_initialize_with,
+             :duplicate_attribute_assignment_from_initialize_with=,
+             :allow_class_lookup, :allow_class_lookup=, to: :configuration
   end
 
   def self.register_factory(factory)

--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -69,10 +69,9 @@ module FactoryGirl
 
   class << self
     delegate :factories, :sequences, :traits, :callbacks, :strategies, :callback_names,
-             :to_create, :skip_create, :initialize_with, :constructor,
-             :duplicate_attribute_assignment_from_initialize_with,
-             :duplicate_attribute_assignment_from_initialize_with=,
-             :allow_class_lookup, :allow_class_lookup=, to: :configuration
+      :to_create, :skip_create, :initialize_with, :constructor,
+      :duplicate_attribute_assignment_from_initialize_with, :duplicate_attribute_assignment_from_initialize_with=,
+      :allow_class_lookup, :allow_class_lookup=, to: :configuration
   end
 
   def self.register_factory(factory)

--- a/lib/factory_girl/configuration.rb
+++ b/lib/factory_girl/configuration.rb
@@ -3,6 +3,8 @@ module FactoryGirl
   class Configuration
     attr_reader :factories, :sequences, :traits, :strategies, :callback_names
 
+    attr_accessor :allow_class_lookup
+
     def initialize
       @factories      = Decorator::DisallowsDuplicatesRegistry.new(Registry.new('Factory'))
       @sequences      = Decorator::DisallowsDuplicatesRegistry.new(Registry.new('Sequence'))
@@ -10,6 +12,8 @@ module FactoryGirl
       @strategies     = Registry.new('Strategy')
       @callback_names = Set.new
       @definition     = Definition.new
+
+      @allow_class_lookup = true
 
       to_create { |instance| instance.save! }
       initialize_with { new }

--- a/lib/factory_girl/decorator/class_key_hash.rb
+++ b/lib/factory_girl/decorator/class_key_hash.rb
@@ -18,7 +18,8 @@ module FactoryGirl
       def symbolized_key(key)
         if key.respond_to?(:to_sym)
           key.to_sym
-        else
+        elsif FactoryGirl.allow_class_lookup
+          ActiveSupport::Deprecation.warn "Looking up factories by class is deprecated and will be removed in 5.0. Use symbols instead and set FactoryGirl.allow_class_lookup = false", caller
           key.to_s.underscore.to_sym
         end
       end

--- a/spec/acceptance/keyed_by_class_spec.rb
+++ b/spec/acceptance/keyed_by_class_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'finding factories keyed by class instead of symbol' do
+describe "finding factories keyed by class instead of symbol" do
   before do
     define_model("User") do
       attr_accessor :name, :email
@@ -8,15 +8,26 @@ describe 'finding factories keyed by class instead of symbol' do
 
     FactoryGirl.define do
       factory :user do
-        name 'John Doe'
+        name "John Doe"
         sequence(:email) { |n| "person#{n}@example.com" }
       end
     end
   end
 
-  it 'allows interaction based on class name' do
-    user = FactoryGirl.create User, email: 'person@example.com'
-    expect(user.email).to eq 'person@example.com'
-    expect(user.name).to eq 'John Doe'
+  context "when deprecated class lookup if allowed", :silence_deprecation do
+    it "allows interaction based on class name" do
+      user = FactoryGirl.create User, email: "person@example.com"
+      expect(user.email).to eq "person@example.com"
+      expect(user.name).to eq "John Doe"
+    end
+  end
+
+  context "when class lookup is disallowed" do
+    it "doesn't find the factory" do
+      FactoryGirl.allow_class_lookup = false
+      expect { FactoryGirl.create(User) }.to(
+        raise_error(ArgumentError, "Factory not registered: User"),
+      )
+    end
   end
 end

--- a/spec/acceptance/transient_attributes_spec.rb
+++ b/spec/acceptance/transient_attributes_spec.rb
@@ -68,14 +68,7 @@ describe "transient attributes" do
     end
   end
 
-  context "using aliased 'ignore' method name" do
-    around do |example|
-      cached_silenced = ActiveSupport::Deprecation.silenced
-      ActiveSupport::Deprecation.silenced = true
-      example.run
-      ActiveSupport::Deprecation.silenced = cached_silenced
-    end
-
+  context "using aliased 'ignore' method name", :silence_deprecation do
     before do
       FactoryGirl.define do
         factory :user_using_ignore, class: User do

--- a/spec/factory_girl/registry_spec.rb
+++ b/spec/factory_girl/registry_spec.rb
@@ -57,12 +57,4 @@ describe FactoryGirl::Registry do
     subject.clear
     expect(subject.count).to be_zero
   end
-
-  it "registers classes" do
-    define_class("User")
-    subject.register(User, registered_object)
-    expect(subject.to_a).to eq [registered_object]
-    expect(subject.find(:user)).to eq registered_object
-    expect(subject.find(User)).to eq registered_object
-  end
 end

--- a/spec/support/macros/deprecation.rb
+++ b/spec/support/macros/deprecation.rb
@@ -1,0 +1,18 @@
+require "active_support"
+
+module SilenceDeprecation
+  def silence_deprecation(example)
+    cached_silenced = ActiveSupport::Deprecation.silenced
+    ActiveSupport::Deprecation.silenced = true
+    example.run
+    ActiveSupport::Deprecation.silenced = cached_silenced
+  end
+end
+
+RSpec.configure do |config|
+  config.include SilenceDeprecation
+
+  config.around :example, silence_deprecation: true do |example|
+    silence_deprecation(example)
+  end
+end


### PR DESCRIPTION
This PR deprecates the ability to look up a factory based on class instead of symbol.

- The acceptance test `keyed_by_class_spec.rb` tests lookup by class
- Add flag `allow_class_lookup` (default `true`)
- Show a deprecation on class lookup warning when flag is true
- Raise an exception on class lookup when flag is false
- Silence deprecation warnings in tests using RSpec metadata

Fixes #871