### PR TITLE
Transient attributes in traits

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -711,16 +711,14 @@ create(:post).author
 Traits can be used within other traits to mix in their attributes.
 
 ```ruby
-FactoryGirl.define do
-  factory :order do
-    trait :completed do
-      completed_at { 3.days.ago }
-    end
+factory :order do
+  trait :completed do
+    completed_at { 3.days.ago }
+  end
 
-    trait :refunded do
-      completed
-      refunded_at { 1.day.ago }
-    end
+  trait :refunded do
+    completed
+    refunded_at { 1.day.ago }
   end
 end
 ```

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -708,7 +708,7 @@ end
 create(:post).author
 ```
 
-Finally, traits can be used within other traits to mix in their attributes.
+Traits can be used within other traits to mix in their attributes.
 
 ```ruby
 FactoryGirl.define do
@@ -723,6 +723,24 @@ FactoryGirl.define do
     end
   end
 end
+```
+
+Finally, traits can accept transient attributes.
+
+```ruby
+factory :invoice do
+  trait :with_amount do
+    transient do
+      amount 1
+    end
+
+    after(:create) do |invoice, evaluator|
+      create :line_item, invoice: invoice, amount: evaluator.amount
+    end
+  end
+end
+
+create :invoice, :with_amount, amount: 2
 ```
 
 Callbacks


### PR DESCRIPTION
I had the use case shown in the [committed example code](https://github.com/thoughtbot/factory_girl/commit/1442c9e040923424a8e153eab3796d1d8b919e2b#diff-df17b1aeaf5e7d797809ea45cc1271acR728), where I wanted to DRY up my creation of associated objects with attributes. It wasn't immediately clear from the docs that this was possible, so I thought this might help some people.

This also [removes](https://github.com/thoughtbot/factory_girl/commit/dacc3467c156c7ba5dc6cc756dd47e9c356a32db) an invocation of `FactoryGirl.define` that was otherwise the only such use within the traits section, to keep the example code consistent.

Thanks for this great project!