### PR TITLE
Allow factories to be linted with build

### DIFF
--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -60,11 +60,13 @@ module FactoryGirl
   # factories - which factories to lint; omit for all factories
   # options:
   #   traits : true - to lint traits as well as factories
+  #   use_build : true - to lint using build instead of create
   def self.lint(*args)
     options = args.extract_options!
     factories_to_lint = args[0] || FactoryGirl.factories
     strategy = options[:traits] ? :factory_and_traits : :factory
-    Linter.new(factories_to_lint, strategy).lint!
+    testing_method = options[:use_build] ? :build : :create
+    Linter.new(factories_to_lint, strategy, testing_method).lint!
   end
 
   class << self

--- a/spec/acceptance/lint_spec.rb
+++ b/spec/acceptance/lint_spec.rb
@@ -40,6 +40,7 @@ The following factories are invalid:
     end
 
     expect { FactoryGirl.lint }.not_to raise_error
+    expect { FactoryGirl.lint use_build: true }.not_to raise_error
   end
 
   it 'allows for selective linting' do
@@ -60,6 +61,7 @@ The following factories are invalid:
       end
 
       FactoryGirl.lint only_valid_factories
+      FactoryGirl.lint only_valid_factories, use_build: true
     end.not_to raise_error
   end
 
@@ -75,6 +77,8 @@ The following factories are invalid:
     end
 
     FactoryGirl.lint FactoryGirl.factories, validate_traits: true
+    FactoryGirl.lint FactoryGirl.factories, validate_traits: true,
+                                            use_build: true
   end
 
   it "allows for additional options without explicit factories" do
@@ -89,6 +93,7 @@ The following factories are invalid:
     end
 
     FactoryGirl.lint validate_traits: true
+    FactoryGirl.lint validate_traits: true, use_build: true
   end
 
   describe "trait validation" do
@@ -116,6 +121,10 @@ The following factories are invalid:
         expect do
           FactoryGirl.lint traits: true
         end.to raise_error FactoryGirl::InvalidFactoryError, error_message
+
+        expect do
+          FactoryGirl.lint traits: true, use_build: true
+        end.to_not raise_error
       end
 
       it "does not raise if a trait produces a valid object" do
@@ -134,6 +143,10 @@ The following factories are invalid:
 
         expect do
           FactoryGirl.lint traits: true
+        end.not_to raise_error
+
+        expect do
+          FactoryGirl.lint traits: true, use_build: true
         end.not_to raise_error
       end
     end
@@ -155,7 +168,10 @@ The following factories are invalid:
 
         expect do
           FactoryGirl.lint traits: false
-          FactoryGirl.lint
+        end.not_to raise_error
+
+        expect do
+          FactoryGirl.lint traits: false, use_build: true
         end.not_to raise_error
       end
     end


### PR DESCRIPTION
Useful for objects that do not support `#save`