### PR TITLE
Add error message when count is missing for create_list

### DIFF
--- a/lib/factory_girl/strategy_syntax_method_registrar.rb
+++ b/lib/factory_girl/strategy_syntax_method_registrar.rb
@@ -25,6 +25,10 @@ module FactoryGirl
       strategy_name = @strategy_name
 
       define_syntax_method("#{strategy_name}_list") do |name, amount, *traits_and_overrides, &block|
+        unless amount.respond_to?(:times)
+          raise ArgumentError, "count missing for #{strategy_name}_list"
+        end
+
         amount.times.map { send(strategy_name, name, *traits_and_overrides, &block) }
       end
     end

--- a/spec/acceptance/create_list_spec.rb
+++ b/spec/acceptance/create_list_spec.rb
@@ -53,6 +53,14 @@ describe "create multiple instances" do
       end
     end
   end
+
+  context "without the count" do
+    subject { FactoryGirl.create_list(:post, title: "The Hunting of the Bear") }
+
+    it "raise ArgumentError with the proper error message" do
+      expect { subject }.to raise_error(ArgumentError, /count missing/)
+    end
+  end
 end
 
 describe "multiple creates and transient attributes to dynamically build attribute lists" do


### PR DESCRIPTION
Closes #889

`create_list` was failing abruptly if the second argument was not count. Give a descriptive error message for this case.