### PR TITLE
Fix warning: `&' interpreted as argument prefix

### DIFF
--- a/lib/factory_girl/linter.rb
+++ b/lib/factory_girl/linter.rb
@@ -84,7 +84,7 @@ module FactoryGirl
 
     def error_message
       lines = invalid_factories.map do |_factory, exceptions|
-        exceptions.map &:message
+        exceptions.map(&:message)
       end.flatten
 
       <<-ERROR_MESSAGE.strip


### PR DESCRIPTION
This fix a small warning. Didn't create test, because the modification is trivial.