### PR TITLE
replaced inject with each_with_object to reduce line

### DIFF
--- a/lib/factory_girl/decorator/attribute_hash.rb
+++ b/lib/factory_girl/decorator/attribute_hash.rb
@@ -7,9 +7,8 @@ module FactoryGirl
       end
 
       def attributes
-        @attributes.inject({}) do |result, attribute_name|
+        @attributes.each_with_object({}) do |attribute_name, result|
           result[attribute_name] = send(attribute_name)
-          result
         end
       end
     end


### PR DESCRIPTION
`each_with_object` doesn't require the hash to be returned at the end of each iteration. this enables us to save a line.

the speed difference between `inject` and `each_with_object` will most likely be inconsequential in this scenario.