### PR TITLE
Adds require line in order to configure test suite successfully

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -31,6 +31,8 @@ Configure your test suite
 ```ruby
 # RSpec
 # spec/support/factory_girl.rb
+require 'factory_girl'
+
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 end


### PR DESCRIPTION
When one runs rspec with spec which uses FactoryGirl with Rails 5 and Ruby 2.3.1, uninitialized constant FactoryGirl (NameError) is raised, because when it attempts to include FactoryGirl::Syntax::Methods, FactoryGirl has not been required at top of the file.