### PR TITLE
Disable all ActiveRecord::Persistence methods in Stub strategy

### DIFF
--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -4,15 +4,29 @@ module FactoryGirl
       @@next_id = 1000
 
       DISABLED_PERSISTENCE_METHODS = [
-        :save,
-        :destroy,
         :connection,
-        :reload,
-        :update_attribute,
-        :update_column,
+        :decrement!,
+        :decrement,
+        :delete,
+        :destroy!,
+        :destroy,
+        :destroyed?,
         :increment!,
-        :decrement!
-      ]
+        :increment,
+        :reload,
+        :save!,
+        :save,
+        :toggle!,
+        :toggle,
+        :touch,
+        :update!,
+        :update,
+        :update_attribute,
+        :update_attributes!,
+        :update_attributes,
+        :update_column,
+        :update_columns,
+      ].freeze
 
       def association(runner)
         runner.run(:build_stubbed)

--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -3,6 +3,17 @@ module FactoryGirl
     class Stub
       @@next_id = 1000
 
+      DISABLED_PERSISTENCE_METHODS = [
+        :save,
+        :destroy,
+        :connection,
+        :reload,
+        :update_attribute,
+        :update_column,
+        :increment!,
+        :decrement!
+      ]
+
       def association(runner)
         runner.run(:build_stubbed)
       end
@@ -33,36 +44,10 @@ module FactoryGirl
             id.nil?
           end
 
-          def save(*args)
-            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#save(#{args.join(",")})"
-          end
-
-          def destroy(*args)
-            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#destroy(#{args.join(",")})"
-          end
-
-          def connection
-            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#connection()"
-          end
-
-          def reload(*args)
-            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#reload()"
-          end
-
-          def update_attribute(*args)
-            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#update_attribute(#{args.join(",")})"
-          end
-
-          def update_column(*args)
-            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#update_column(#{args.join(",")})"
-          end
-
-          def increment!(*args)
-            raise "stubbed models are not allowed to access the database - #{self.class}#increment!(#{args.join(',')})"
-          end
-
-          def decrement!(*args)
-            raise "stubbed models are not allowed to access the database - #{self.class}#decrement!(#{args.join(',')})"
+          DISABLED_PERSISTENCE_METHODS.each do |write_method|
+            define_singleton_method(write_method) do |*args|
+              raise "stubbed models are not allowed to access the database - #{self.class}##{write_method}(#{args.join(",")})"
+            end
           end
         end
 

--- a/spec/factory_girl/strategy/stub_spec.rb
+++ b/spec/factory_girl/strategy/stub_spec.rb
@@ -27,7 +27,16 @@ describe FactoryGirl::Strategy::Stub do
       expect(subject.result(evaluation).created_at).to eq created_at
     end
 
-    [:save, :destroy, :connection, :reload, :update_attribute, :update_column].each do |database_method|
+    [
+      :save,
+      :destroy,
+      :connection,
+      :reload,
+      :update_attribute,
+      :update_column,
+      :increment!,
+      :decrement!
+    ].each do |database_method|
       it "raises when attempting to connect to the database by calling #{database_method}" do
         expect do
           subject.result(evaluation).send(database_method)

--- a/spec/factory_girl/strategy/stub_spec.rb
+++ b/spec/factory_girl/strategy/stub_spec.rb
@@ -46,13 +46,27 @@ describe FactoryGirl::Strategy::Stub do
       expect(subject.result(evaluation).created_at).to eq created_at
     end
 
-    include_examples "disabled persistence method", :save
-    include_examples "disabled persistence method", :destroy
     include_examples "disabled persistence method", :connection
-    include_examples "disabled persistence method", :reload
-    include_examples "disabled persistence method", :update_attribute
-    include_examples "disabled persistence method", :update_column
-    include_examples "disabled persistence method", :increment!
+    include_examples "disabled persistence method", :decrement
     include_examples "disabled persistence method", :decrement!
+    include_examples "disabled persistence method", :delete
+    include_examples "disabled persistence method", :destroy
+    include_examples "disabled persistence method", :destroy!
+    include_examples "disabled persistence method", :destroyed?
+    include_examples "disabled persistence method", :increment
+    include_examples "disabled persistence method", :increment!
+    include_examples "disabled persistence method", :reload
+    include_examples "disabled persistence method", :save
+    include_examples "disabled persistence method", :save!
+    include_examples "disabled persistence method", :toggle
+    include_examples "disabled persistence method", :toggle!
+    include_examples "disabled persistence method", :touch
+    include_examples "disabled persistence method", :update
+    include_examples "disabled persistence method", :update!
+    include_examples "disabled persistence method", :update_attribute
+    include_examples "disabled persistence method", :update_attributes
+    include_examples "disabled persistence method", :update_attributes!
+    include_examples "disabled persistence method", :update_column
+    include_examples "disabled persistence method", :update_columns
   end
 end

--- a/spec/factory_girl/strategy/stub_spec.rb
+++ b/spec/factory_girl/strategy/stub_spec.rb
@@ -1,5 +1,24 @@
 require 'spec_helper'
 
+shared_examples "disabled persistence method" do |method_name|
+  let(:instance) { described_class.new.result(evaluation) }
+
+  describe "overriding persistence method: ##{method_name}" do
+    it "overrides the method with any arity" do
+      method = instance.method(method_name)
+
+      expect(method.arity).to eq(-1)
+    end
+
+    it "raises an informative error if the method is called" do
+      expect { instance.send(method_name) }.to raise_error(
+        RuntimeError,
+        "stubbed models are not allowed to access the database - #{instance.class}##{method_name}()",
+      )
+    end
+  end
+end
+
 describe FactoryGirl::Strategy::Stub do
   it_should_behave_like "strategy with association support", :build_stubbed
   it_should_behave_like "strategy with callbacks", :after_stub
@@ -27,28 +46,13 @@ describe FactoryGirl::Strategy::Stub do
       expect(subject.result(evaluation).created_at).to eq created_at
     end
 
-    [
-      :save,
-      :destroy,
-      :connection,
-      :reload,
-      :update_attribute,
-      :update_column,
-      :increment!,
-      :decrement!
-    ].each do |database_method|
-      it "raises when attempting to connect to the database by calling #{database_method}" do
-        expect do
-          subject.result(evaluation).send(database_method)
-        end.to raise_error(RuntimeError, "stubbed models are not allowed to access the database - #{subject.result(evaluation).class}##{database_method}()")
-      end
-    end
-
-    it "raises when attempting to connect to the database by calling reload with optional lock:true" do
-      expect do
-        subject.result(evaluation).reload(lock: true)
-      end.to raise_error(RuntimeError, "stubbed models are not allowed to access the database - #{subject.result(evaluation).class}#reload()")
-    end
-
+    include_examples "disabled persistence method", :save
+    include_examples "disabled persistence method", :destroy
+    include_examples "disabled persistence method", :connection
+    include_examples "disabled persistence method", :reload
+    include_examples "disabled persistence method", :update_attribute
+    include_examples "disabled persistence method", :update_column
+    include_examples "disabled persistence method", :increment!
+    include_examples "disabled persistence method", :decrement!
   end
 end


### PR DESCRIPTION
Was: "Don't allow `#save!` to be called on stubbed instances"

The `Stub` strategy is used to build instances that appear to be persisted, but don't write to the database. The stubs created have a [number of methods overwritten](https://github.com/thoughtbot/factory_girl/blob/07ece7c4169a3c3d9adce4471b3f790c460af7a4/lib/factory_girl/strategy/stub.rb#L36-L66) to prevent subsequent interaction with the database.

However, `#save!` is not included, meaning that it can be called on stubs without error (as can other methods like `#touch` that eventually call `#save!`).

Adding it to the blacklist is a simple change, but I'd like to check that its omission wasn't intentional. I can't find any specific reference to it in the history so I assume it's just an oversight - can anyone who's worked on the `Stub` strategy think of any reason it might've been deliberately left out?

Another thing worth considering: this change will probably break a few test suites out there. Is the benefit of consistency worth the downside of having a breaking change?