### PR TITLE
exclude rubies that rails 5.0 does not support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.2.2
-  - 2.3.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
   - jruby-19mode
   - rbx-2
 before_install:
@@ -20,15 +20,16 @@ gemfile:
   - gemfiles/5.0.gemfile
 matrix:
   fast_finish: true
-  allow_failures:
+  exclude:
     - rvm: jruby-19mode
       gemfile: gemfiles/5.0.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/5.0.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/5.0.gemfile
-    - rvm: 2.1.0
+    - rvm: 2.1.10
       gemfile: gemfiles/5.0.gemfile
+  allow_failures:
     - rvm: rbx-2
       gemfile: gemfiles/5.0.gemfile
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.3.1
   - jruby-19mode
   - rbx-2
+  - rbx-3
 before_install:
   - gem update --system
   - gem update bundler
@@ -29,9 +30,11 @@ matrix:
       gemfile: gemfiles/5.0.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/5.0.gemfile
-  allow_failures:
     - rvm: rbx-2
       gemfile: gemfiles/5.0.gemfile
+  allow_failures:
+    - rvm: rbx-2
+    - rvm: rbx-3
 branches:
   only:
     - master


### PR DESCRIPTION
was looking at your travis and saw these allowed failures.
you can actually exclude build for unsupported version.

I'm not sure if rbx-2 should be able to run rails 5, so I left that one under allowed_failures

also bump minor versions of recent rubies

cheers
