### PR TITLE
Moved inheritance above associations in the Getting Started guide

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -288,6 +288,42 @@ end
 
 ```
 
+Inheritance
+-----------
+
+You can easily create multiple factories for the same class without repeating common attributes by nesting factories:
+
+```ruby
+factory :post do
+  title "A title"
+
+  factory :approved_post do
+    approved true
+  end
+end
+
+approved_post = create(:approved_post)
+approved_post.title    # => "A title"
+approved_post.approved # => true
+```
+
+You can also assign the parent explicitly:
+
+```ruby
+factory :post do
+  title "A title"
+end
+
+factory :approved_post, parent: :post do
+  approved true
+end
+```
+
+As mentioned above, it's good practice to define a basic factory for each class
+with only the attributes required to create it. Then, create more specific
+factories that inherit from this basic parent. Factory definitions are still
+code, so keep them DRY.
+
 Associations
 ------------
 
@@ -441,42 +477,6 @@ create(:profile).languages.length # 0
 create(:profile_with_languages).languages.length # 5
 create(:profile_with_languages, languages_count: 15).languages.length # 15
 ```
-
-Inheritance
------------
-
-You can easily create multiple factories for the same class without repeating common attributes by nesting factories:
-
-```ruby
-factory :post do
-  title "A title"
-
-  factory :approved_post do
-    approved true
-  end
-end
-
-approved_post = create(:approved_post)
-approved_post.title    # => "A title"
-approved_post.approved # => true
-```
-
-You can also assign the parent explicitly:
-
-```ruby
-factory :post do
-  title "A title"
-end
-
-factory :approved_post, parent: :post do
-  approved true
-end
-```
-
-As mentioned above, it's good practice to define a basic factory for each class
-with only the attributes required to create it. Then, create more specific
-factories that inherit from this basic parent. Factory definitions are still
-code, so keep them DRY.
 
 Sequences
 ---------


### PR DESCRIPTION
I was reading through the Getting Started guide and noticed that Inheritance is introduced in the Associations section which precedes the Inheritance section. Since the Inheritance section is small I think it flows better to introduce it first, then it makes more sense when you encounter it in the Associations section. 
