### PR TITLE
Add info about list methods

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -936,11 +936,23 @@ To set the attributes for each of the factories, you can pass in a hash as you n
 twenty_year_olds = build_list(:user, 25, date_of_birth: 20.years.ago)
 ```
 
+`build_stubbed_list` will give you fully stubbed out instances:
+
+```ruby
+stubbed_users = build_stubbed_list(:user, 25) # array of stubbed users
+```
+
 There's also a set of `*_pair` methods for creating two records at a time:
 
 ```ruby
 built_users   = build_pair(:user) # array of two built users
 created_users = create_pair(:user) # array of two created users
+```
+
+If you need multiple attribute hashes, `attributes_for_list` will generate them:
+
+```ruby
+users_attrs = attributes_for_list(:user, 25) # array of attribute hashes
 ```
 
 Linting Factories


### PR DESCRIPTION
This adds information about the `build_stubbed_list` and `attributes_for_list` methods as documented [here](http://www.rubydoc.info/github/thoughtbot/factory_girl/FactoryGirl/Syntax/Methods). These methods, like many things, helped me refactor out some less aesthetic code that did the same thing in my tests.