### PR TITLE
Add section to README about project naming history

### DIFF
--- a/NAME.md
+++ b/NAME.md
@@ -1,0 +1,11 @@
+# Why is this project called "Factory Girl"?
+
+The name "Factory Girl" might be confusing to some developers who encounter this
+library.
+
+[We chose the name](https://robots.thoughtbot.com/waiting-for-a-factory-girl) as
+a nod in the direction of the [Factory method](https://en.wikipedia.org/wiki/Factory_method_pattern)
+and [Object Mother](http://martinfowler.com/bliki/ObjectMother.html) software
+patterns from the _Design Patterns_ book, and as a reference to the
+[Rolling Stones song](https://www.youtube.com/watch?v=4jKix2DFlnA) of the same
+name.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ factory_girl is a fixtures replacement with a straightforward definition syntax,
 If you want to use factory_girl with Rails, see
 [factory_girl_rails](https://github.com/thoughtbot/factory_girl_rails).
 
+_[Interested in the project name?](NAME.md)._
+
 Documentation
 -------------
 


### PR DESCRIPTION
This is an attempt to address the concerns raised in https://github.com/thoughtbot/factory_girl/issues/921 and https://github.com/thoughtbot/factory_girl/issues/849 without a full project rename.