### PR TITLE
Updating dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    sqlite3 (1.3.11)
+    sqlite3 (1.3.12)
     thor (0.19.1)
     thread_safe (0.3.5)
     thread_safe (0.3.5-java)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,29 +7,27 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.5.1)
-      activesupport (= 4.2.5.1)
-      builder (~> 3.1)
-    activerecord (4.2.5.1)
-      activemodel (= 4.2.5.1)
-      activesupport (= 4.2.5.1)
-      arel (~> 6.0)
-    activerecord-jdbc-adapter (1.3.19)
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activerecord (5.0.0.1)
+      activemodel (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      arel (~> 7.0)
+    activerecord-jdbc-adapter (1.3.21)
       activerecord (>= 2.2)
-    activerecord-jdbcsqlite3-adapter (1.3.19)
-      activerecord-jdbc-adapter (~> 1.3.19)
+    activerecord-jdbcsqlite3-adapter (1.3.21)
+      activerecord-jdbc-adapter (~> 1.3.21)
       jdbc-sqlite3 (>= 3.7.2, < 3.9)
-    activesupport (4.2.5.1)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
-    arel (6.0.3)
+    arel (7.1.4)
     aruba (0.13.0)
       childprocess (~> 0.5.6)
       contracts (~> 0.9)
@@ -42,6 +40,8 @@ GEM
     builder (3.2.2)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
+    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.2-java)
     contracts (0.13.0)
     cucumber (1.3.20)
       builder (>= 2.1.2)
@@ -62,7 +62,7 @@ GEM
     json (1.8.3)
     json (1.8.3-java)
     metaclass (0.0.4)
-    minitest (5.8.4)
+    minitest (5.9.1)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
@@ -120,4 +120,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
Updating the following gems:
- `activerecord-jdbcsqlite3-adapter`
- `sqlite3`

to fulfill #953 and remove the Gemnasium security alert! Let me know if you need anything else from me for this issue 🙂
