### PR TITLE
Add use_parent_strategy option for building associations

### DIFF
--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -68,10 +68,23 @@ module FactoryGirl
   end
 
   class << self
-    delegate :factories, :sequences, :traits, :callbacks, :strategies, :callback_names,
-      :to_create, :skip_create, :initialize_with, :constructor,
-      :duplicate_attribute_assignment_from_initialize_with, :duplicate_attribute_assignment_from_initialize_with=,
-      :allow_class_lookup, :allow_class_lookup=, to: :configuration
+    delegate :factories,
+             :sequences,
+             :traits,
+             :callbacks,
+             :strategies,
+             :callback_names,
+             :to_create,
+             :skip_create,
+             :initialize_with,
+             :constructor,
+             :duplicate_attribute_assignment_from_initialize_with,
+             :duplicate_attribute_assignment_from_initialize_with=,
+             :allow_class_lookup,
+             :allow_class_lookup=,
+             :use_parent_strategy,
+             :use_parent_strategy=,
+             to: :configuration
   end
 
   def self.register_factory(factory)

--- a/lib/factory_girl/configuration.rb
+++ b/lib/factory_girl/configuration.rb
@@ -3,7 +3,7 @@ module FactoryGirl
   class Configuration
     attr_reader :factories, :sequences, :traits, :strategies, :callback_names
 
-    attr_accessor :allow_class_lookup
+    attr_accessor :allow_class_lookup, :use_parent_strategy
 
     def initialize
       @factories      = Decorator::DisallowsDuplicatesRegistry.new(Registry.new('Factory'))

--- a/lib/factory_girl/evaluator.rb
+++ b/lib/factory_girl/evaluator.rb
@@ -23,7 +23,9 @@ module FactoryGirl
 
     def association(factory_name, *traits_and_overrides)
       overrides = traits_and_overrides.extract_options!
-      strategy_override = overrides.fetch(:strategy) { :create }
+      strategy_override = overrides.fetch(:strategy) do
+        FactoryGirl.use_parent_strategy ? @build_strategy.class : :create
+      end
 
       traits_and_overrides += [overrides.except(:strategy)]
 

--- a/spec/acceptance/build_spec.rb
+++ b/spec/acceptance/build_spec.rb
@@ -23,13 +23,33 @@ describe "a built instance" do
 
   it { should be_new_record }
 
-  it "assigns and saves associations" do
+  context "when the :use_parent_strategy config option has not been set" do
+    before { FactoryGirl.use_parent_strategy = nil }
+
+    it "assigns and saves associations" do
+      expect(subject.user).to be_kind_of(User)
+      expect(subject.user).not_to be_new_record
+    end
+  end
+
+  context "when the :use_parent_strategy config option has been enabled" do
+    before { FactoryGirl.use_parent_strategy = true }
+
+    it "assigns but does not save associations" do
+      expect(subject.user).to be_kind_of(User)
+      expect(subject.user).to be_new_record
+    end
+  end
+
+  it "assigns but does not save associations when using parent strategy" do
+    FactoryGirl.use_parent_strategy = true
+
     expect(subject.user).to be_kind_of(User)
-    expect(subject.user).not_to be_new_record
+    expect(subject.user).to be_new_record
   end
 end
 
-describe "a built instance with strategy: :build" do
+describe "a built instance with strategy: :create" do
   include FactoryGirl::Syntax::Methods
 
   before do
@@ -43,7 +63,7 @@ describe "a built instance with strategy: :build" do
       factory :user
 
       factory :post do
-        association(:user, strategy: :build)
+        association(:user, strategy: :create)
       end
     end
   end
@@ -52,9 +72,9 @@ describe "a built instance with strategy: :build" do
 
   it { should be_new_record }
 
-  it "assigns but does not save associations" do
+  it "assigns and saves associations" do
     expect(subject.user).to be_kind_of(User)
-    expect(subject.user).to be_new_record
+    expect(subject.user).not_to be_new_record
   end
 end
 

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -35,7 +35,7 @@ describe "a generated stub instance" do
   end
 
   it "assigns associations" do
-    expect(subject.user).not_to be_nil
+    expect(subject.user).to be_kind_of(User)
   end
 
   it "has an id" do
@@ -49,6 +49,10 @@ describe "a generated stub instance" do
 
   it "isn't a new record" do
     expect(subject).not_to be_new_record
+  end
+
+  it "assigns associations that aren't new records" do
+    expect(subject.user).not_to be_new_record
   end
 
   it "isn't changed" do

--- a/spec/acceptance/register_strategies_spec.rb
+++ b/spec/acceptance/register_strategies_spec.rb
@@ -100,10 +100,26 @@ describe "associations without overriding :strategy" do
     end
   end
 
-  it "uses the overridden create strategy to create the association" do
-    FactoryGirl.register_strategy(:create, custom_strategy)
-    post = FactoryGirl.build(:post)
-    expect(post.user.name).to eq "Custom strategy"
+  context "when the :use_parent_strategy config option has not been enabled" do
+    before { FactoryGirl.use_parent_strategy = nil }
+
+    it "uses the overridden strategy on the association" do
+      FactoryGirl.register_strategy(:create, custom_strategy)
+
+      post = FactoryGirl.build(:post)
+      expect(post.user.name).to eq "Custom strategy"
+    end
+  end
+
+  context "when the :use_parent_strategy config option has been enabled" do
+    before { FactoryGirl.use_parent_strategy = true }
+
+    it "uses the parent strategy on the association" do
+      FactoryGirl.register_strategy(:create, custom_strategy)
+
+      post = FactoryGirl.build(:post)
+      expect(post.user.name).to eq "John Doe"
+    end
   end
 end
 


### PR DESCRIPTION
### Description

Picking up where https://github.com/thoughtbot/factory_girl/pull/749 left off.

This PR adds a `FactoryGirl.use_parent_strategy` configuration option, allowing factory associations to follow the parent's build strategy.  Previously, all factory associations were
created, regardless of whether the parent was persisted to the database.

The configuration option is off by default, so there is no change to the current behavior.
