### PR TITLE
Remove 'RSpec' heading from code block

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -28,8 +28,9 @@ Once your Gemfile is updated, you'll want to update your bundle.
 Configure your test suite
 -------------------------
 
-```ruby
 # RSpec
+
+```ruby
 # spec/support/factory_girl.rb
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
Aside from being unclear, this also seemed to be effecting the code block parsing for the remainder of the file (see screenshots below)

--------------

**The hosted version:**

![hosted](https://cloud.githubusercontent.com/assets/3201135/20447021/92659992-adaa-11e6-82fa-cdeb91fbd056.png)

**My version previewed in** `YARD`:

![mine](https://cloud.githubusercontent.com/assets/3201135/20447024/9753314e-adaa-11e6-8d0e-d48e2cc501d4.png)
