### PR TITLE
Stub out ActiveRecord::Base#destroyed?

### DIFF
--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -10,7 +10,6 @@ module FactoryGirl
         :delete,
         :destroy!,
         :destroy,
-        :destroyed?,
         :increment!,
         :increment,
         :reload,
@@ -56,6 +55,10 @@ module FactoryGirl
 
           def new_record?
             id.nil?
+          end
+
+          def destroyed?
+            nil
           end
 
           DISABLED_PERSISTENCE_METHODS.each do |write_method|

--- a/spec/factory_girl/strategy/stub_spec.rb
+++ b/spec/factory_girl/strategy/stub_spec.rb
@@ -36,6 +36,7 @@ describe FactoryGirl::Strategy::Stub do
 
     it { expect(subject.result(evaluation)).not_to be_new_record }
     it { expect(subject.result(evaluation)).to be_persisted }
+    it { expect(subject.result(evaluation)).not_to be_destroyed }
 
     it "assigns created_at" do
       created_at = subject.result(evaluation).created_at
@@ -52,7 +53,6 @@ describe FactoryGirl::Strategy::Stub do
     include_examples "disabled persistence method", :delete
     include_examples "disabled persistence method", :destroy
     include_examples "disabled persistence method", :destroy!
-    include_examples "disabled persistence method", :destroyed?
     include_examples "disabled persistence method", :increment
     include_examples "disabled persistence method", :increment!
     include_examples "disabled persistence method", :reload


### PR DESCRIPTION
See #981 for more details

FactoryGirl 4.8.0 updated some logic to make sure to raise on all ActiveRecord::Persistence methods.

However the `destroyed?` method seems like it is easily stubbed on the Stub object and allows the ActiveRecord::AutosaveAssociation#save_belongs_to_association method to work with stubbed objects again