### PR TITLE
Update lint example to configure DatabaseCleaner

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -987,6 +987,8 @@ namespace :factory_girl do
   task lint: :environment do
     if Rails.env.test?
       begin
+        DatabaseCleaner.strategy = :transaction
+        DatabaseCleaner.clean_with(:deletion)
         DatabaseCleaner.start
         FactoryGirl.lint
       ensure


### PR DESCRIPTION
Not specifying `strategy`/`clean_with` can lead to test data sticking around on CI and cause unique validations to fail while the lint process is running.