### PR TITLE
Allow instance to be accessed from evaluator

### DIFF
--- a/lib/factory_girl/evaluator.rb
+++ b/lib/factory_girl/evaluator.rb
@@ -33,20 +33,18 @@ module FactoryGirl
       @build_strategy.association(runner)
     end
 
-    def instance=(object_instance)
-      @instance = object_instance
-    end
+    attr_accessor :instance
 
     def method_missing(method_name, *args, &block)
-      if @instance.respond_to?(method_name)
-        @instance.send(method_name, *args, &block)
+      if instance.respond_to?(method_name)
+        instance.send(method_name, *args, &block)
       else
         SyntaxRunner.new.send(method_name, *args, &block)
       end
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      @instance.respond_to?(method_name) || SyntaxRunner.new.respond_to?(method_name)
+      instance.respond_to?(method_name) || SyntaxRunner.new.respond_to?(method_name)
     end
 
     def __override_names__

--- a/spec/acceptance/definition_spec.rb
+++ b/spec/acceptance/definition_spec.rb
@@ -52,3 +52,45 @@ describe "attributes defined using Symbol#to_proc" do
     expect(user.password_confirmation).to eq "bar"
   end
 end
+
+describe "defining has_many associations in an association block" do
+  before do
+    define_model("User") do
+      has_many :posts
+      attr_accessor :favorite_post
+    end
+    define_model("Post", user_id: :integer) { belongs_to :user }
+
+    FactoryGirl.define do
+      factory :user do
+        posts { build_list(:post, 2, user: instance) }
+        favorite_post { posts.last }
+      end
+
+      factory :post do
+        user
+      end
+    end
+  end
+
+  it "correctly sets the opposite association on build" do
+    user = FactoryGirl.build(:user)
+
+    expect(user.posts.size).to eq(2)
+    expect(user.posts.map(&:user)).to all(eq(user))
+  end
+
+  it "correctly sets the opposite association on create" do
+    user = FactoryGirl.create(:user)
+
+    expect(user.posts.count).to eq(2)
+    expect(user.posts.map(&:user)).to all(eq(user))
+  end
+
+  it "is usable in other blocks" do
+    user = FactoryGirl.build(:user)
+
+    expect(user.favorite_post).to be_a(Post)
+    expect(user.favorite_post).to eq(user.posts.last)
+  end
+end


### PR DESCRIPTION
This will allow for the following:

```ruby
factory :post do
  user
end

factory :user do
  posts { build_list(:post, 2, user: instance) }
end
```

I think this is an improvement because it allows for accessing association objects prior to callbacks, which I feel makes for writing factories that are easier to follow.