### PR TITLE
Allow selective linting of single factories

### DIFF
--- a/lib/factory_girl/linter.rb
+++ b/lib/factory_girl/linter.rb
@@ -2,7 +2,7 @@ module FactoryGirl
   class Linter
 
     def initialize(factories_to_lint, linting_strategy)
-      @factories_to_lint = factories_to_lint
+      @factories_to_lint = force_enumerable(factories_to_lint)
       @linting_method = "lint_#{linting_strategy}"
       @invalid_factories = calculate_invalid_factories
     end
@@ -17,6 +17,14 @@ module FactoryGirl
     private :factories_to_lint, :invalid_factories
 
     private
+
+    def force_enumerable(factories)
+      if factories.respond_to?(:each)
+        factories
+      else
+        Array(factories)
+      end
+    end
 
     def calculate_invalid_factories
       factories_to_lint.reduce(Hash.new([])) do |result, factory|

--- a/spec/acceptance/lint_spec.rb
+++ b/spec/acceptance/lint_spec.rb
@@ -91,6 +91,20 @@ The following factories are invalid:
     FactoryGirl.lint validate_traits: true
   end
 
+  it "allows selective linting with single factories" do
+    define_model 'User', name: :string do
+      validates :name, presence: true
+    end
+
+    FactoryGirl.define do
+      factory :user do
+        name 'assigned'
+      end
+    end
+
+    expect { FactoryGirl.lint(FactoryGirl.factories.first) }.not_to raise_error
+  end
+
   describe "trait validation" do
     context "enabled" do
       it "raises if a trait produces an invalid object" do


### PR DESCRIPTION
Before these changes: `FactoryGirl.lint(FactoryGirl.factories.first)` raises error, since `.lint` expected an Enumerable (`FactoryGirl::Registry` by default).

This change allows to pass single factories to be linted, without the need of adding them to an enumerable collection:

Before: `FactoryGirl.lint([FactoryGirl.factories.first])`
With this change, simply: `FactoryGirl.lint(FactoryGirl.factories.first)`

Next step to achieve greater linting flexibility would be to allow selective linting by factory names, instead of full factory objects.