### PR TITLE
Loosen up the stub behavior to work nicely in Rails 5

### DIFF
--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -10,7 +10,6 @@ module FactoryGirl
         :delete,
         :destroy!,
         :destroy,
-        :destroyed?,
         :increment!,
         :increment,
         :reload,
@@ -50,6 +49,10 @@ module FactoryGirl
         result_instance.id ||= next_id
 
         result_instance.instance_eval do
+          def destroyed?
+            false
+          end
+
           def persisted?
             !new_record?
           end


### PR DESCRIPTION
During the migration from Rails 4.2.7 to 5.0.2, I ran into an issue where ActiveRecord tried to autosave my stubbed associations, and called `#destroyed?`. This patch resolved my issue.

I'm not sure what the correct solution is, but thought to open this up in case I'm not the only one that runs into this.