### PR TITLE
Do not raise error for increment and decrement in stubs.

### DIFF
--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -6,13 +6,11 @@ module FactoryGirl
       DISABLED_PERSISTENCE_METHODS = [
         :connection,
         :decrement!,
-        :decrement,
         :delete,
         :destroy!,
         :destroy,
         :destroyed?,
         :increment!,
-        :increment,
         :reload,
         :save!,
         :save,

--- a/spec/factory_girl/strategy/stub_spec.rb
+++ b/spec/factory_girl/strategy/stub_spec.rb
@@ -47,13 +47,11 @@ describe FactoryGirl::Strategy::Stub do
     end
 
     include_examples "disabled persistence method", :connection
-    include_examples "disabled persistence method", :decrement
     include_examples "disabled persistence method", :decrement!
     include_examples "disabled persistence method", :delete
     include_examples "disabled persistence method", :destroy
     include_examples "disabled persistence method", :destroy!
     include_examples "disabled persistence method", :destroyed?
-    include_examples "disabled persistence method", :increment
     include_examples "disabled persistence method", :increment!
     include_examples "disabled persistence method", :reload
     include_examples "disabled persistence method", :save


### PR DESCRIPTION
Right now an error is raised when increment or decrement is called. But those methods don't access the database, increment! and decrement! do. 

I think factory girl should allow these methods.

https://github.com/thoughtbot/factory_girl/issues/996