### PR TITLE
Simplify DatabaseCleaner code example for linter

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -986,11 +986,8 @@ namespace :factory_girl do
   desc "Verify that all FactoryGirl factories are valid"
   task lint: :environment do
     if Rails.env.test?
-      begin
-        DatabaseCleaner.start
+      DatabaseCleaner.cleaning do
         FactoryGirl.lint
-      ensure
-        DatabaseCleaner.clean
       end
     else
       system("bundle exec rake factory_girl:lint RAILS_ENV='test'")


### PR DESCRIPTION
The `cleaning` method already ensures cleaning and provides for a way to write better looking code.

This should be 100% equivalent to previous example.