### PR TITLE
Improve lint rake task example to return proper exit code

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -994,6 +994,7 @@ namespace :factory_girl do
       end
     else
       system("bundle exec rake factory_girl:lint RAILS_ENV='test'")
+      exit $?.exitstatus
     end
   end
 end


### PR DESCRIPTION
This will make sure to return whatever the system call returned and it's useful to chain shell calls, etc.