### PR TITLE
Fix test order dependent failures with seeds 50350 + 48550

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.2.5
   - 2.3.1
   - ruby-head
-  - jruby-19mode
   - rbx-2
 before_install:
   - gem update --system
@@ -30,8 +29,6 @@ matrix:
       gemfile: gemfiles/5.0.gemfile
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-19mode
-      gemfile: gemfiles/5.0.gemfile
     - rvm: rbx-2
 branches:
   only:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,11 @@ RSpec.configure do |config|
 
   config.include DeclarationMatchers
 
+  config.before do
+    FactoryGirl.reload
+  end
+
   config.after do
     Timecop.return
-    FactoryGirl.reload
   end
 end


### PR DESCRIPTION
I noticed a couple of tests fail intermittently whilst setting up the project to contribute. 

Using `rspec --bisect` to hunt down the minimal reproductions:

## Seed 50350

```
bundle exec rspec './spec/acceptance/define_child_before_parent_spec.rb[1:1]' './spec/factory_girl/definition_spec.rb[3:1]' --seed 50350
``` 

```

Run options: include {:ids=>{"./spec/acceptance/define_child_before_parent_spec.rb"=>["1:1"], "./spec/factory_girl/definition_spec.rb"=>["3:1"]}}

Randomized with seed 50350
.F

Failures:

  1) defining a child factory before a parent creates admin factories correctly
     Failure/Error: declarations.attributes

     Mocha::ExpectationError:
       unexpected invocation: #<Mock:declaration list>.attributes()
     # ./lib/factory_girl/definition.rb:47:in `compile'
     # ./lib/factory_girl/definition.rb:127:in `aggregate_from_traits_and_self'
     # ./lib/factory_girl/definition.rb:38:in `constructor'
     # ./lib/factory_girl/configuration.rb:22:in `constructor'
     # ./lib/factory_girl.rb:71:in `constructor'
     # ./lib/factory_girl/definition_hierarchy.rb:8:in `constructor'
     # ./lib/factory_girl/factory.rb:136:in `compiled_constructor'
     # ./lib/factory_girl/factory.rb:37:in `run'
     # ./lib/factory_girl/factory_runner.rb:29:in `block in run'
     # ./lib/factory_girl/factory_runner.rb:28:in `run'
     # ./lib/factory_girl/strategy_syntax_method_registrar.rb:20:in `block in define_singular_strategy_method'
     # ./spec/acceptance/define_child_before_parent_spec.rb:19:in `block (2 levels) in <top (required)>'

Finished in 0.19463 seconds (files took 0.40745 seconds to load)
2 examples, 1 failure
```

## Seed 48550

```
bundle exec rspec './spec/acceptance/register_strategies_spec.rb[3:2:1]' './spec/factory_girl/definition_spec.rb[2:1]' --seed 48550
```

```
Run options: include {:ids=>{"./spec/acceptance/register_strategies_spec.rb"=>["3:2:1"], "./spec/factory_girl/definition_spec.rb"=>["2:1"]}}

Randomized with seed 48550
.F

Failures:

  1) associations without overriding :strategy when the :use_parent_strategy config option has been enabled uses the parent strategy on the association
     Failure/Error: declarations.attributes

     NoMethodError:
       undefined method `attributes' for nil:NilClass
     # ./lib/factory_girl/definition.rb:47:in `compile'
     # ./lib/factory_girl/definition.rb:127:in `aggregate_from_traits_and_self'
     # ./lib/factory_girl/definition.rb:38:in `constructor'
     # ./lib/factory_girl/configuration.rb:22:in `constructor'
     # ./lib/factory_girl.rb:71:in `constructor'
     # ./lib/factory_girl/definition_hierarchy.rb:8:in `constructor'
     # ./lib/factory_girl/factory.rb:136:in `compiled_constructor'
     # ./lib/factory_girl/factory.rb:37:in `run'
     # ./lib/factory_girl/factory_runner.rb:29:in `block in run'
     # ./lib/factory_girl/factory_runner.rb:28:in `run'
     # ./lib/factory_girl/strategy_syntax_method_registrar.rb:20:in `block in define_singular_strategy_method'
     # ./spec/acceptance/register_strategies_spec.rb:120:in `block (3 levels) in <top (required)>'

Finished in 0.19997 seconds (files took 0.41345 seconds to load)
2 examples, 1 failure
```