### PR TITLE
Linting factory strategy

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1030,6 +1030,12 @@ This can also be combined with other arguments:
 FactoryGirl.lint factories_to_lint, traits: true
 ```
 
+You can also specify the strategy used for linting:
+
+```ruby
+FactoryGirl.lint strategy: :build
+```
+
 Custom Construction
 -------------------
 

--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -59,12 +59,14 @@ module FactoryGirl
   # Parameters:
   # factories - which factories to lint; omit for all factories
   # options:
-  #   traits : true - to lint traits as well as factories
+  #   traits: true - to lint traits as well as factories
+  #   strategy: :create - to specify the strategy for linting
   def self.lint(*args)
     options = args.extract_options!
     factories_to_lint = args[0] || FactoryGirl.factories
-    strategy = options[:traits] ? :factory_and_traits : :factory
-    Linter.new(factories_to_lint, strategy).lint!
+    linting_strategy = options[:traits] ? :factory_and_traits : :factory
+    factory_strategy = options[:strategy] || :create
+    Linter.new(factories_to_lint, linting_strategy, factory_strategy).lint!
   end
 
   class << self

--- a/spec/acceptance/lint_spec.rb
+++ b/spec/acceptance/lint_spec.rb
@@ -160,4 +160,50 @@ The following factories are invalid:
       end
     end
   end
+
+  describe "factory strategy for linting" do
+    it "uses the requested strategy" do
+      define_class "User" do
+        attr_accessor :name
+
+        def save!
+          raise "expected :build strategy, #save! shouldn't be invoked"
+        end
+      end
+
+      FactoryGirl.define do
+        factory :user do
+          name "Barbara"
+        end
+      end
+
+      expect do
+        FactoryGirl.lint strategy: :build
+      end.not_to raise_error
+    end
+
+    it "uses the requested strategy during trait validation" do
+      define_class "User" do
+        attr_accessor :name
+
+        def save!
+          raise "expected :build strategy, #save! shouldn't be invoked"
+        end
+      end
+
+      FactoryGirl.define do
+        factory :user do
+          name "Barbara"
+
+          trait :male do
+            name "Bob"
+          end
+        end
+      end
+
+      expect do
+        FactoryGirl.lint traits: true, strategy: :build
+      end.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
When using FactoryGirl with non-ActiveRecord objects it would be useful to allow the strategy used for linting to be specified:

```ruby
FactoryGirl.lint strategy: :build
```

---

~~Based on #1018 to get a green build. Will point base branch to `master` if the other PR is resolved.~~