### PR TITLE
Update migration base class to work with new versions of Rails

### DIFF
--- a/features/support/factories.rb
+++ b/features/support/factories.rb
@@ -1,11 +1,18 @@
 ActiveRecord::Base.establish_connection(
-  :adapter  => 'sqlite3',
-  :database => File.join(File.dirname(__FILE__), 'test.db')
+  adapter: 'sqlite3',
+  database: File.join(File.dirname(__FILE__), 'test.db')
 )
 
-class CreateSchema < ActiveRecord::Migration
+migration_class =
+  if ActiveRecord::Migration.respond_to?(:[])
+    ActiveRecord::Migration[4.2]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateSchema < migration_class
   def self.up
-    create_table :categories, :force => true do |t|
+    create_table :categories, force: true do |t|
       t.string :name
     end
   end


### PR DESCRIPTION
What?
=====

Rails' migrations now support versioning; this updates the superclass to
conditionally swap based on versions of Rails to remove a deprecation
warning.